### PR TITLE
🔍 Add 9 service×city SEO landing pages

### DIFF
--- a/cloture-bois-merignac.html
+++ b/cloture-bois-merignac.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Clôture Bois Mérignac (33700) | Artisan Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Clôture bois sur mesure à Mérignac (33700) : brise-vue, piscine, portail. Solutions anti-bruit pour quartiers proches aéroport. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="clôture bois Mérignac, clôture bois 33700, brise-vue Mérignac, clôture piscine Mérignac, portail bois Mérignac, palissade Mérignac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Mérignac, Gironde">
+  <meta name="geo.position" content="44.8417;-0.6533">
+  <meta name="ICBM" content="44.8417, -0.6533">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Clôture Bois Mérignac (33700) | Élégance Bois">
+  <meta property="og:description" content="Pose clôture bois sur mesure à Mérignac. Brise-vue, piscine, portail. Solutions anti-bruit. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/cloture-bois-merignac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/cloture-portail.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/cloture-bois-merignac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/cloture-portail.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/cloture-portail.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Clôture bois</a></li>
+        <li aria-current="page">Mérignac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Clôture Bois Sur Mesure à Mérignac</h1>
+        <p class="hero-tagline">Solutions adaptées au tissu urbain mérignacais</p>
+        <p>Capeyron, Arlac, Beutre, Pichey, Beaudésert — clôtures bois sur mesure pour chaque quartier de Mérignac (33700).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Mérignac, troisième commune de Gironde par sa population, mêle <strong>tissu pavillonnaire dense</strong>, secteurs résidentiels haut de gamme (Arlac, Le Burck) et zones soumises au plan d'exposition au bruit de l'aéroport. Cette particularité change la donne : nos clients mérignacais cherchent souvent davantage qu'un brise-vue, ils veulent un <strong>complément d'isolement acoustique</strong> au jardin.</p>
+        <p>Une clôture bois pleine en pin classe 4 ou en châtaignier, combinée à une haie végétale, atténue efficacement les bruits de fond aérien et routier — sans le rendu froid d'un mur béton. Nous adaptons l'épaisseur des lames et leur jonction pour maximiser cet effet.</p>
+        <p>Côté sol, Mérignac présente des terrains <strong>argilo-limoneux</strong> typiques de la métropole bordelaise, sujets au retrait-gonflement. Nous adaptons systématiquement nos scellements pour éviter tout désaxage de clôture sur la durée.</p>
+      </div>
+
+      <h2>Types de clôtures bois posées à Mérignac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Palissade pleine acoustique</h3>
+          <p>Notre solution la plus demandée à Mérignac : lames jointives serrées, hauteur jusqu'à 2,20 m, effet brise-bruit notable côté jardin.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Volige verticale</h3>
+          <p>Élégance contemporaine pour les résidences d'Arlac, Le Burck et secteurs résidentiels haut de gamme. Brise-vue total.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture ajourée</h3>
+          <p>Pour les pavillons de Capeyron et Beaudésert, où le PLU recommande une transparence visuelle partielle côté rue.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture persiennée</h3>
+          <p>Lames inclinées : intimité côté voisin, lumière côté jardin. Idéale pour les terrains orientés sud.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture piscine NF P90-306</h3>
+          <p>Mérignac compte de nombreuses propriétés avec piscine. Notre solution bois respecte la norme tout en restant esthétique.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Portail bois assorti</h3>
+          <p>Battant ou coulissant, manuel ou motorisé, en cohérence stylistique avec votre clôture.</p>
+        </div>
+      </div>
+
+      <h2>Essences recommandées à Mérignac</h2>
+      <p>Nous sélectionnons l'essence selon votre quartier, votre exposition et votre budget :</p>
+      <ul>
+        <li><strong>Pin maritime classe 4</strong> : essence d'origine régionale, traitement autoclave, durabilité 15-20 ans, prix maîtrisé.</li>
+        <li><strong>Châtaignier</strong> : naturellement imputrescible, durabilité 25 ans, patine grise élégante — privilégié dans les quartiers patrimoniaux.</li>
+        <li><strong>Douglas</strong> : excellent compromis prix/qualité, tons chauds, sans traitement chimique nécessaire.</li>
+        <li><strong>Mélèze</strong> : très stable, idéal pour les palissades acoustiques (peu de retrait, lames jointives durables).</li>
+        <li><strong>Ipé / Cumaru</strong> : haut de gamme, durée de vie 50+ ans, pour propriétés d'exception.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Mérignac</strong>Déplacement offert sous 48h dans tous les quartiers : Centre, Capeyron, Beutre, Arlac, Pichey, Beaudésert, Le Burck, Chemin Long.</li>
+        <li><strong>Diagnostic technique</strong>Sol, exposition, contraintes acoustiques, zonage PLU, présence éventuelle de servitudes (réseaux enterrés Bordeaux Métropole).</li>
+        <li><strong>Devis et démarches mairie</strong>Déclaration préalable obligatoire à Mérignac. Nous préparons et déposons votre dossier.</li>
+        <li><strong>Fabrication et pose</strong>Chantier en 2 à 5 jours selon longueur et type. Équipe locale, propreté garantie.</li>
+        <li><strong>Garantie décennale</strong>Suivi à 12 mois, conseils d'entretien, SAV réactif.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une clôture bois à Mérignac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type</th><th>Essence</th><th>Tarif (ml, pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Ajourée standard</td><td>Pin classe 4</td><td>130 - 190 €</td></tr>
+          <tr><td>Volige verticale</td><td>Pin / Douglas</td><td>160 - 230 €</td></tr>
+          <tr><td>Palissade acoustique</td><td>Pin / Mélèze</td><td>180 - 270 €</td></tr>
+          <tr><td>Persiennée</td><td>Douglas / Châtaignier</td><td>190 - 280 €</td></tr>
+          <tr><td>Clôture piscine NF</td><td>Châtaignier</td><td>210 - 330 €</td></tr>
+          <tr><td>Haut de gamme</td><td>Ipé / Chêne</td><td>300 - 480 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs au ml, devis personnalisé selon votre quartier et la nature du terrain.</em></p>
+
+      <h2>Pourquoi nous confier votre clôture à Mérignac ?</h2>
+      <ul>
+        <li><strong>Expertise solutions anti-bruit</strong> pour les quartiers concernés par le plan d'exposition aéroport</li>
+        <li><strong>Maîtrise du PLU Mérignac et Bordeaux Métropole</strong></li>
+        <li><strong>Pose adaptée aux sols argileux</strong> pour stabilité long terme</li>
+        <li><strong>Délais courts</strong> : intervention sous 2 à 4 semaines</li>
+        <li><strong>Garantie décennale</strong>, note clients 5/5, références locales</li>
+      </ul>
+
+      <h2>Autres services à Mérignac et communes voisines</h2>
+      <div class="local-links">
+        <a href="terrasse-bois-merignac.html">Terrasse bois Mérignac</a>
+        <a href="pergola-bois-merignac.html">Pergola bois Mérignac</a>
+        <a href="cloture-bois-pessac.html">Clôture Pessac</a>
+        <a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — clôture bois à Mérignac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Une clôture bois atténue-t-elle vraiment le bruit aérien à Mérignac ?</summary>
+        <div class="faq-answer"><p>Une clôture bois pleine de 2 m réduit le bruit perçu de 5 à 8 dB côté jardin (effet barrière). Combinée à une haie végétale dense, l'atténuation atteint 10-12 dB — perceptible, surtout pour les fréquences moyennes. Le bois est ici supérieur au métal et comparable au béton, avec un rendu chaleureux.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quelles règles PLU à Mérignac pour une clôture ?</summary>
+        <div class="faq-answer"><p>Hauteur maximale 2 m en limite séparative, 1,60 m en bordure de voie pour la partie pleine. Déclaration préalable obligatoire. Dans les secteurs UA (centre dense) et UC (résidentiels), des prescriptions architecturales peuvent s'appliquer. Nous vérifions le zonage de votre parcelle.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Intervenez-vous dans tous les quartiers de Mérignac ?</summary>
+        <div class="faq-answer"><p>Oui : Centre, Capeyron, Beutre, Arlac, Pichey, Beaudésert, Le Burck, Chemin Long, La Glacière. Saint-Jean d'Illac jouxte Mérignac côté ouest, déplacement rapide garanti.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quelle est la durée de vie d'une clôture bois à Mérignac ?</summary>
+        <div class="faq-answer"><p>Pin classe 4 : 15-20 ans. Douglas / Mélèze : 20-25 ans. Châtaignier : 25-30 ans sans traitement. Ipé : 50 ans et plus. Un entretien tous les 3-5 ans (saturateur) prolonge significativement la durée de vie.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre clôture bois à Mérignac — devis gratuit</h2>
+        <p>Déplacement offert dans tous les quartiers, étude technique incluse.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan clôture, terrasse et pergola bois à Mérignac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="cloture-bois-merignac.html">Clôture Mérignac</a></li>
+            <li><a href="terrasse-bois-merignac.html">Terrasse Mérignac</a></li>
+            <li><a href="pergola-bois-merignac.html">Pergola Mérignac</a></li>
+            <li><a href="cloture-bois-pessac.html">Clôture Pessac</a></li>
+            <li><a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Pose de clôture bois sur mesure",
+    "name": "Clôture bois Mérignac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Mérignac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Bordeaux Métropole"}},
+    "description": "Conception et pose de clôtures bois sur mesure à Mérignac (33700) : palissade acoustique, volige, ajourée, persiennée, clôture piscine NF, portail.",
+    "offers": {"@type": "Offer", "priceRange": "130-480 EUR/ml", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Clôture bois Mérignac", "item": "https://elegance-bois.fr/cloture-bois-merignac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/cloture-bois-pessac.html
+++ b/cloture-bois-pessac.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Clôture Bois Pessac (33600) | Pose Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Artisan clôture bois sur mesure à Pessac (33600) : volige, ajourée, persiennée, piscine. Pin classe 4, châtaignier, ipé. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="clôture bois Pessac, clôture bois 33600, palissade Pessac, clôture piscine Pessac, portail bois Pessac, artisan clôture Pessac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Pessac, Gironde">
+  <meta name="geo.position" content="44.8067;-0.6311">
+  <meta name="ICBM" content="44.8067, -0.6311">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Clôture Bois Pessac (33600) | Élégance Bois">
+  <meta property="og:description" content="Pose clôture bois sur mesure à Pessac. Volige, ajourée, persiennée, piscine. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/cloture-bois-pessac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/cloture-portail.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/cloture-bois-pessac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/cloture-portail.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/cloture-portail.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Clôture bois</a></li>
+        <li aria-current="page">Pessac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Clôture Bois Sur Mesure à Pessac</h1>
+        <p class="hero-tagline">Artisan girondin, intervention rapide dans toute la commune</p>
+        <p>De Saige à Magonty, du Bourg à Cap-de-Bos — clôtures bois conçues et posées sur mesure à Pessac (33600).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Pessac, deuxième ville de Gironde par sa population, présente une diversité urbaine rare : <strong>échoppes bordelaises classées en centre</strong>, lotissements pavillonnaires des années 70 à Saige, propriétés viticoles autour de l'AOC Pessac-Léognan, résidences contemporaines à Magonty. Chaque quartier impose ses propres règles d'urbanisme et chaque terrain ses contraintes.</p>
+        <p>Nous intervenons depuis Saint-Jean d'Illac, commune voisine, ce qui nous permet d'atteindre Pessac en moins de 20 minutes. Nous maîtrisons le <strong>PLU de Bordeaux Métropole</strong> appliqué à Pessac — particulièrement strict sur les hauteurs en bordure de voie et sur les essences visibles depuis la rue dans les secteurs patrimoniaux.</p>
+        <p>Sur un sol pessacais souvent <strong>argilo-limoneux</strong> (très différent du sable illacais), nos poses prennent en compte le retrait-gonflement des argiles, fréquent dans la métropole bordelaise. Cela conditionne la profondeur des scellements et le type de béton utilisé.</p>
+      </div>
+
+      <h2>Types de clôtures bois posées à Pessac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Clôture ajourée discrète</h3>
+          <p>Recommandée pour les échoppes du Bourg et secteurs patrimoniaux où le PLU exige une transparence partielle vers la rue.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Volige verticale moderne</h3>
+          <p>Très demandée dans les résidences contemporaines de Magonty et Saige. Lignes épurées, brise-vue intégral.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture persiennée orientable</h3>
+          <p>Lames inclinées pour préserver l'intimité côté voisin tout en laissant passer la lumière depuis votre jardin.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture piscine NF P90-306</h3>
+          <p>Conforme aux obligations légales. Solution discrète et chaleureuse vs le verre froid ou le métal.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Palissade pleine et claustra mixte</h3>
+          <p>Pour les jardins arrière donnant sur copropriété ou voie passante. Hauteur adaptée au PLU pessacais.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Portail bois sur mesure</h3>
+          <p>Battant ou coulissant, motorisable. Finitions assorties à votre clôture pour une cohérence parfaite.</p>
+        </div>
+      </div>
+
+      <h2>Essences de bois adaptées au climat pessacais</h2>
+      <p>Climat océanique tempéré, pluviométrie soutenue d'octobre à mars, étés secs : nos recommandations pour Pessac :</p>
+      <ul>
+        <li><strong>Pin classe 4 autoclave</strong> : meilleur rapport durabilité/prix, traitement contre humidité et insectes (15-20 ans).</li>
+        <li><strong>Châtaignier</strong> : essence noble sans traitement, prend une belle patine grise — apprécié dans les quartiers à caractère patrimonial.</li>
+        <li><strong>Douglas</strong> : alternative naturellement durable, tons rouge-orangé chaleureux.</li>
+        <li><strong>Chêne</strong> : pour clôtures d'exception, en cohérence avec l'esprit châteaux Pessac-Léognan.</li>
+        <li><strong>Ipé</strong> : bois exotique haut de gamme, durée de vie 50+ ans pour les propriétés de prestige.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Pessac</strong>Déplacement offert sous 48h dans tous les quartiers : Bourg, Saige, Magonty, Cap-de-Bos, Médoquine, Les Échoppes.</li>
+        <li><strong>Étude technique et devis détaillé</strong>Analyse du sol (argileux ? limoneux ?), du zonage PLU, vérification des servitudes éventuelles.</li>
+        <li><strong>Démarches en mairie</strong>Déclaration préalable de travaux : nous préparons le Cerfa, vous signez, nous déposons à l'hôtel de ville de Pessac.</li>
+        <li><strong>Fabrication et pose</strong>Atelier à Saint-Jean d'Illac. Chantier généralement réalisé en 2 à 4 jours selon longueur. Propreté garantie.</li>
+        <li><strong>Garantie décennale et SAV</strong>Suivi à 1 an, conseils d'entretien, intervention rapide en cas de besoin.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une clôture bois à Pessac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type</th><th>Essence</th><th>Tarif (ml, pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Ajourée patrimoniale</td><td>Pin classe 4</td><td>130 - 190 €</td></tr>
+          <tr><td>Volige verticale</td><td>Pin / Douglas</td><td>160 - 230 €</td></tr>
+          <tr><td>Persiennée orientable</td><td>Douglas / Châtaignier</td><td>190 - 280 €</td></tr>
+          <tr><td>Palissade pleine</td><td>Pin classe 4</td><td>170 - 250 €</td></tr>
+          <tr><td>Clôture piscine NF</td><td>Châtaignier</td><td>210 - 330 €</td></tr>
+          <tr><td>Haut de gamme</td><td>Ipé / Chêne</td><td>300 - 480 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs au mètre linéaire. Devis personnalisé gratuit selon votre quartier et le terrain.</em></p>
+
+      <h2>Pourquoi nous confier votre clôture à Pessac ?</h2>
+      <ul>
+        <li><strong>Connaissance fine du PLU pessacais</strong> et des spécificités par secteur (patrimonial, pavillonnaire, contemporain)</li>
+        <li><strong>Pose adaptée au sol argileux</strong> de la métropole bordelaise (scellements drainés, béton dosé)</li>
+        <li><strong>Délais courts</strong> : intervention sous 2 à 4 semaines après acceptation devis</li>
+        <li><strong>Note clients 5/5</strong>, références locales sur demande</li>
+        <li><strong>Garantie décennale</strong> et assurance professionnelle</li>
+      </ul>
+
+      <h2>Autres services bois à Pessac et communes voisines</h2>
+      <div class="local-links">
+        <a href="terrasse-bois-pessac.html">Terrasse bois Pessac</a>
+        <a href="pergola-bois-pessac.html">Pergola bois Pessac</a>
+        <a href="cloture-bois-merignac.html">Clôture bois Mérignac</a>
+        <a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — clôture bois à Pessac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Quelles règles d'urbanisme s'appliquent aux clôtures à Pessac ?</summary>
+        <div class="faq-answer"><p>Le PLU de Bordeaux Métropole appliqué à Pessac fixe la hauteur maximale en limite séparative à 2 m et en bordure de voie à 1,60 m pour les parties pleines. Une déclaration préalable est obligatoire. Dans les secteurs patrimoniaux (centre-bourg, abords églises), des restrictions supplémentaires s'appliquent. Nous vérifions le zonage exact de votre parcelle.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Sol argileux à Pessac : quelles précautions ?</summary>
+        <div class="faq-answer"><p>L'argile gonfle en hiver et se rétracte en été, ce qui peut désaxer une clôture mal posée. Nous descendons les poteaux sous la zone de retrait (60-80 cm minimum), utilisons un béton dosé à 350 kg/m³, et prévoyons un drainage. Cette technique est incluse dans nos devis Pessac sans surcoût.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Intervenez-vous dans tous les quartiers de Pessac ?</summary>
+        <div class="faq-answer"><p>Oui : Bourg, Saige, Magonty, Cap-de-Bos, Bersol, Le Monteil, La Châtaigneraie, Les Échoppes, Médoquine, Toctoucau, Romainville. Déplacement offert sur toute la commune.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Combien de temps prend la pose d'une clôture à Pessac ?</summary>
+        <div class="faq-answer"><p>Pour 40 à 80 ml, comptez 2 à 4 jours de chantier. Délai global (devis → pose finalisée) : 2 à 4 semaines hors saison, 4 à 6 semaines en pleine saison (avril-juin).</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre clôture bois à Pessac, devis gratuit sous 48h</h2>
+        <p>Déplacement offert, étude technique incluse, garantie décennale.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan clôture, terrasse et pergola bois à Pessac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="cloture-bois-pessac.html">Clôture Pessac</a></li>
+            <li><a href="terrasse-bois-pessac.html">Terrasse Pessac</a></li>
+            <li><a href="pergola-bois-pessac.html">Pergola Pessac</a></li>
+            <li><a href="cloture-bois-merignac.html">Clôture Mérignac</a></li>
+            <li><a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Pose de clôture bois sur mesure",
+    "name": "Clôture bois Pessac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Pessac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Bordeaux Métropole"}},
+    "description": "Conception et pose de clôtures bois sur mesure à Pessac (33600) : volige, ajourée, persiennée, palissade, clôture piscine NF P90-306, portail.",
+    "offers": {"@type": "Offer", "priceRange": "130-480 EUR/ml", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Clôture bois Pessac", "item": "https://elegance-bois.fr/cloture-bois-pessac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/cloture-bois-saint-jean-d-illac.html
+++ b/cloture-bois-saint-jean-d-illac.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Clôture Bois Saint-Jean d'Illac (33127) | Artisan Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Clôture bois sur mesure à Saint-Jean d'Illac (33127) : volige, ajourée, persiennée, clôture piscine NF P90-306. Pin classe 4, chêne, châtaignier. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="clôture bois Saint-Jean d'Illac, clôture bois 33127, clôture jardin Saint-Jean d'Illac, palissade bois Saint-Jean d'Illac, clôture piscine Saint-Jean d'Illac, portail bois Saint-Jean d'Illac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Saint-Jean d'Illac, Gironde">
+  <meta name="geo.position" content="44.8167;-0.7833">
+  <meta name="ICBM" content="44.8167, -0.7833">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Clôture Bois Saint-Jean d'Illac (33127) | Élégance Bois">
+  <meta property="og:description" content="Pose de clôture bois sur mesure à Saint-Jean d'Illac. Volige, ajourée, persiennée, piscine. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/cloture-bois-saint-jean-d-illac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/cloture-volige-saint-jean-d-illac.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/cloture-bois-saint-jean-d-illac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/cloture-volige-saint-jean-d-illac.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+
+  <style>.landing-hero{--landing-hero-img:url('img/cloture-volige-saint-jean-d-illac.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Clôture bois</a></li>
+        <li aria-current="page">Saint-Jean d'Illac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Clôture Bois Sur Mesure à Saint-Jean d'Illac</h1>
+        <p class="hero-tagline">L'artisan bois de votre commune, depuis plus de 15 ans</p>
+        <p>Volige, ajourée, persiennée ou clôture piscine — chaque ouvrage conçu, fabriqué et posé localement à Saint-Jean d'Illac (33127).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Basés <strong>228 rue des Tamaris à Saint-Jean d'Illac</strong>, nous sommes l'artisan bois historique de la commune. Cette implantation locale change tout : un déplacement offert à toute heure, une connaissance fine du <strong>sol sableux landais</strong> qui domine sur la commune, et une maîtrise des contraintes d'urbanisme propres au territoire — du lotissement résidentiel des Tamaris jusqu'aux propriétés en lisière de la forêt usagère.</p>
+        <p>Une clôture bois posée à Saint-Jean d'Illac doit composer avec un sol drainant qui exige des <strong>ancrages plus profonds qu'en terre argileuse</strong>, une humidité ambiante forte due à la proximité du Bassin d'Arcachon, et un PLU communal qui réglemente précisément les hauteurs en limite de voirie. Nous gérons l'ensemble — étude technique, déclaration préalable si nécessaire, choix de l'essence, pose.</p>
+      </div>
+
+      <h2>Types de clôtures bois que nous posons à Saint-Jean d'Illac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Clôture en volige</h3>
+          <p>Notre signature locale, déjà installée chez plusieurs propriétaires de la commune. Lames verticales serrées pour un brise-vue total tout en gardant respiration et patine bois.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture ajourée</h3>
+          <p>Lames espacées de 1 à 3 cm, idéale pour les jardins de devant à Saint-Jean d'Illac où le PLU recommande des clôtures semi-perméables visuellement.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture persiennée</h3>
+          <p>Lames inclinées qui filtrent le regard sans bloquer la lumière. Parfaite pour les terrains exposés sud-ouest, fréquents sur la commune.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Clôture piscine NF P90-306</h3>
+          <p>Conforme à la norme de sécurité piscines. Sur sol sableux illacais, nous adaptons les fixations pour garantir la stabilité long terme.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Palissade pleine</h3>
+          <p>Occultation 100%, hauteur jusqu'à 2,20 m selon zonage PLU. Recommandée pour les terrains en limite de la D106 ou de la route de Bordeaux.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Portail et portillon bois</h3>
+          <p>Assortis à votre clôture, motorisables. Conçus pour résister aux variations hygrométriques fortes du climat girondin.</p>
+        </div>
+      </div>
+
+      <h2>Essences de bois recommandées à Saint-Jean d'Illac</h2>
+      <p>Le micro-climat illacais — humidité, embruns occasionnels, écarts thermiques modérés — guide notre sélection des essences :</p>
+      <ul>
+        <li><strong>Pin maritime traité autoclave classe 4</strong> : essence locale par excellence, issue des forêts landaises voisines. Rapport qualité/prix imbattable, durabilité 15-20 ans.</li>
+        <li><strong>Châtaignier</strong> : naturellement imputrescible, sans traitement chimique. Patine grise élégante après 2 ans.</li>
+        <li><strong>Chêne</strong> : pour les clôtures de prestige, durée de vie 30 ans et plus.</li>
+        <li><strong>Douglas</strong> : alternative au pin, tons plus chauds, excellente tenue.</li>
+        <li><strong>Ipé ou cumaru</strong> : essences exotiques pour finition haut de gamme, durée de vie 50+ ans.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Saint-Jean d'Illac</strong>Nous nous déplaçons sous 48h pour mesurer, analyser le terrain et écouter votre projet.</li>
+        <li><strong>Devis détaillé et personnalisé</strong>Plan, choix d'essence, hauteur, finitions, délais. Tout transparent, sans engagement.</li>
+        <li><strong>Démarches administratives</strong>Nous vous accompagnons sur la déclaration préalable de travaux auprès de la mairie de Saint-Jean d'Illac si nécessaire.</li>
+        <li><strong>Fabrication et pose</strong>Atelier local, intervention en 1 à 3 jours selon la longueur. Scellement béton, alignement laser, finitions soignées.</li>
+        <li><strong>Garantie et suivi</strong>Garantie décennale, contrôle à 1 an, conseils d'entretien personnalisés.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une clôture bois à Saint-Jean d'Illac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type de clôture</th><th>Essence</th><th>Prix indicatif (ml, pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Ajourée standard</td><td>Pin classe 4</td><td>120 - 180 €</td></tr>
+          <tr><td>Volige verticale</td><td>Pin classe 4 / Douglas</td><td>150 - 220 €</td></tr>
+          <tr><td>Persiennée</td><td>Pin classe 4 / Douglas</td><td>180 - 260 €</td></tr>
+          <tr><td>Palissade pleine</td><td>Pin classe 4</td><td>160 - 240 €</td></tr>
+          <tr><td>Clôture piscine NF</td><td>Châtaignier / Pin</td><td>200 - 320 €</td></tr>
+          <tr><td>Haut de gamme</td><td>Ipé / Chêne</td><td>280 - 450 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs, ml = mètre linéaire. Devis personnalisé gratuit selon votre projet.</em></p>
+
+      <h2>Pourquoi un artisan local à Saint-Jean d'Illac ?</h2>
+      <p>Une clôture posée par un artisan extérieur à la commune, c'est souvent un sous-traitant qui ne connaît ni le sol ni les voisins. Nous, nous croisons nos clients au marché du samedi.</p>
+      <ul>
+        <li><strong>Déplacement offert</strong> sur toute la commune (Tamaris, Bourg, Le Pujeau, Las Salles, Cap-de-Bos)</li>
+        <li><strong>Connaissance du PLU</strong> illacais et des règles de hauteur en limite séparative</li>
+        <li><strong>Disponibilité SAV</strong> rapide : un ajustement ? Nous passons.</li>
+        <li><strong>Références locales vérifiables</strong> chez vos voisins, sur demande</li>
+      </ul>
+
+      <h2>Communes voisines où nous intervenons</h2>
+      <p>Au-delà de Saint-Jean d'Illac, nous posons régulièrement chez nos voisins immédiats :</p>
+      <div class="local-links">
+        <a href="cloture-bois-pessac.html">Clôture bois Pessac</a>
+        <a href="cloture-bois-merignac.html">Clôture bois Mérignac</a>
+        <a href="terrasse-bois-saint-jean-d-illac.html">Terrasse bois Saint-Jean d'Illac</a>
+        <a href="pergola-bois-saint-jean-d-illac.html">Pergola bois Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — clôture bois à Saint-Jean d'Illac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Faut-il une déclaration préalable pour une clôture à Saint-Jean d'Illac ?</summary>
+        <div class="faq-answer"><p>Oui dès que la hauteur dépasse 2 m, ou systématiquement si votre terrain est en secteur classé (lisière forêt usagère, abords monuments). Nous préparons le dossier et le déposons à la mairie de Saint-Jean d'Illac pour vous.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Le sol sableux d'Illac pose-t-il problème pour les poteaux ?</summary>
+        <div class="faq-answer"><p>Non, à condition d'adapter la pose : nous descendons les scellements à 70-80 cm au lieu de 50 cm habituels, et utilisons un béton plus dosé. Cette adaptation locale est incluse dans nos devis sans surcoût.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quelle hauteur maximale pour une clôture à Saint-Jean d'Illac ?</summary>
+        <div class="faq-answer"><p>Le PLU autorise jusqu'à 2 m en limite séparative et 1,60 m en bordure de voie publique pour la partie pleine. Au-delà, il faut une partie ajourée. Nous vérifions le zonage exact de votre parcelle avant chantier.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Combien de temps dure une pose de clôture sur la commune ?</summary>
+        <div class="faq-answer"><p>Entre 1 et 3 jours pour 30 à 80 ml. Nous travaillons en équipe réduite, sans bruit excessif, sans gêner les voisins. Atelier local = pas de logistique perdue.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Prêt à clôturer votre terrain à Saint-Jean d'Illac ?</h2>
+        <p>Devis gratuit sous 48h, déplacement offert sur toute la commune.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan clôture, terrasse et pergola bois à Saint-Jean d'Illac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a></li>
+            <li><a href="cloture-bois-pessac.html">Clôture Pessac</a></li>
+            <li><a href="cloture-bois-merignac.html">Clôture Mérignac</a></li>
+            <li><a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a></li>
+            <li><a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Pose de clôture bois sur mesure",
+    "name": "Clôture bois Saint-Jean d'Illac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Saint-Jean d'Illac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Gironde"}},
+    "description": "Conception et pose de clôtures bois sur mesure à Saint-Jean d'Illac (33127) : volige, ajourée, persiennée, palissade, clôture piscine NF P90-306, portail.",
+    "offers": {"@type": "Offer", "priceRange": "120-450 EUR/ml", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Clôture bois Saint-Jean d'Illac", "item": "https://elegance-bois.fr/cloture-bois-saint-jean-d-illac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -650,12 +650,17 @@
             </ul>
           </div>
           <div class="footer-column">
-            <h4>Zone d'intervention</h4>
+            <h4>Zones d'intervention</h4>
             <ul class="footer-links">
-              <li>CUB</li>
-              <li>Bassin d'Arcachon</li>
-              <li>Médoc</li>
-              <li>Entre-Deux-Mers</li>
+              <li><a href="/cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a></li>
+              <li><a href="/cloture-bois-pessac.html">Clôture Pessac</a></li>
+              <li><a href="/cloture-bois-merignac.html">Clôture Mérignac</a></li>
+              <li><a href="/terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a></li>
+              <li><a href="/terrasse-bois-pessac.html">Terrasse Pessac</a></li>
+              <li><a href="/terrasse-bois-merignac.html">Terrasse Mérignac</a></li>
+              <li><a href="/pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a></li>
+              <li><a href="/pergola-bois-pessac.html">Pergola Pessac</a></li>
+              <li><a href="/pergola-bois-merignac.html">Pergola Mérignac</a></li>
             </ul>
           </div>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -935,9 +935,20 @@
         this.tagElements();
         this.observeReveals();
       }
+      this.initHeaderScroll();
       if (this.heroBg) {
         this.initParallax();
       }
+    }
+
+    initHeaderScroll() {
+      const header = document.querySelector('header');
+      if (!header) return;
+      const onScroll = () => {
+        header.classList.toggle('scrolled', window.scrollY > 40);
+      };
+      window.addEventListener('scroll', onScroll, { passive: true });
+      onScroll();
     }
 
     tagElements() {
@@ -1000,16 +1011,12 @@
     }
 
     initParallax() {
-      const header = document.querySelector('header');
       const onScroll = () => {
         if (!this.ticking) {
           requestAnimationFrame(() => {
             const scrollY = window.scrollY;
             if (this.heroBg && scrollY < window.innerHeight) {
               this.heroBg.style.transform = `translateY(${scrollY * 0.35}px)`;
-            }
-            if (header) {
-              header.classList.toggle('scrolled', scrollY > 40);
             }
             this.ticking = false;
           });

--- a/pergola-bois-merignac.html
+++ b/pergola-bois-merignac.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Pergola Bois Mérignac (33700) | Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Pergola bois sur mesure à Mérignac (33700) : adossée, autoportée, persiennes orientables. Solutions intimité jardin. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="pergola bois Mérignac, pergola bois 33700, pergola adossée Mérignac, pergola Arlac, pergola Capeyron, pergola persiennes Mérignac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Mérignac, Gironde">
+  <meta name="geo.position" content="44.8417;-0.6533">
+  <meta name="ICBM" content="44.8417, -0.6533">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Pergola Bois Mérignac (33700) | Élégance Bois">
+  <meta property="og:description" content="Pergola bois sur mesure à Mérignac. Adossée, autoportée, persiennes orientables. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/pergola-bois-merignac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/pergola.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/pergola-bois-merignac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/pergola.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/pergola.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Pergola bois</a></li>
+        <li aria-current="page">Mérignac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Pergola Bois Sur Mesure à Mérignac</h1>
+        <p class="hero-tagline">Créez votre îlot de calme et d'ombre au jardin</p>
+        <p>Pergolas bois adossées, autoportées, à persiennes orientables — sur mesure pour Mérignac (33700).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>À Mérignac, la pergola bois répond souvent à un double besoin : <strong>créer un coin ombragé</strong> sur la terrasse pour les après-midis chaudes, et <strong>filtrer visuellement</strong> le voisinage dans des quartiers résidentiels où les parcelles sont parfois rapprochées. Une pergola avec persiennes orientables ou claustra latéral résout les deux d'un coup.</p>
+        <p>Notre atelier à Saint-Jean d'Illac (commune voisine) nous place à 10-15 minutes de tous les quartiers mérignacais — Capeyron, Arlac, Beutre, Pichey, Beaudésert, Le Burck. Cette proximité change tout pour la phase de pose (allers-retours sans logistique perdue) et pour le SAV ultérieur.</p>
+        <p>Sur le plan technique, le sol mérignacais — argilo-limoneux avec parfois remblais — exige des fondations adaptées. Nous calculons les sections de poteaux pour les vents girondins (jusqu'à 130 km/h) et la neige réglementaire de zone.</p>
+      </div>
+
+      <h2>Types de pergolas à Mérignac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Pergola adossée façade</h3>
+          <p>La plus demandée à Mérignac : prolonge naturellement la pièce de vie sur la terrasse. Ancrage sur façade existante.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola autoportée jardin</h3>
+          <p>Indépendante, idéale pour les jardins de Beaudésert ou Le Burck. Crée un point de gravité extérieur.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Persiennes orientables</h3>
+          <p>Lames pivotantes pour moduler l'ombre. Réglage manuel par manivelle ou motorisé par télécommande.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola + claustra latéral</h3>
+          <p>Notre solution complète intimité : pergola dessus, claustra bois sur 1 ou 2 côtés. Cocon discret et ombragé.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Toile rétractable</h3>
+          <p>Flexibilité : ouverte au printemps, fermée en plein été. Manuelle ou motorisée avec capteur soleil-vent.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola tour de piscine</h3>
+          <p>Coin lecture/repas ombragé attenant à votre piscine. Bois traité résistant chlore.</p>
+        </div>
+      </div>
+
+      <h2>Essences bois recommandées à Mérignac</h2>
+      <ul>
+        <li><strong>Pin lamellé-collé classe 4</strong> : meilleur rapport prix/structure, sections importantes possibles pour grandes portées.</li>
+        <li><strong>Douglas</strong> : durable sans traitement, tons rouge-orangé qui patinent en gris argenté.</li>
+        <li><strong>Mélèze</strong> : très stable, peu de fente, idéal pour pergolas à lignes épurées contemporaines.</li>
+        <li><strong>Chêne</strong> : pour pergolas patrimoniales, durabilité 40+ ans.</li>
+        <li><strong>Ipé</strong> : pour les lames de couverture ou habillages apparents, durée 50+ ans.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Mérignac</strong>Sous 48h, tous quartiers. Mesures, orientation, étude du sol, contraintes voisinage.</li>
+        <li><strong>Plan personnalisé</strong>Choix essence, dimensions, type de couverture, claustra latéral éventuel, motorisation.</li>
+        <li><strong>Démarches administratives</strong>Déclaration préalable obligatoire à Mérignac dès 5 m². Nous préparons et déposons le dossier.</li>
+        <li><strong>Fabrication et pose</strong>2 à 5 jours selon complexité. Plots béton dimensionnés au sol argileux mérignacais.</li>
+        <li><strong>Finitions et garantie</strong>Lasure ou saturateur, électrification options. Garantie décennale, suivi à 1 an.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une pergola bois à Mérignac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type de pergola</th><th>Surface</th><th>Tarif (pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Adossée pin lamellé</td><td>3×4 m</td><td>3 000 - 4 500 €</td></tr>
+          <tr><td>Adossée douglas</td><td>3×4 m</td><td>4 000 - 5 800 €</td></tr>
+          <tr><td>Autoportée pin lamellé</td><td>4×4 m</td><td>4 500 - 6 500 €</td></tr>
+          <tr><td>Avec persiennes orientables</td><td>3×4 m</td><td>5 800 - 9 000 €</td></tr>
+          <tr><td>Avec claustra latéral intimité</td><td>3×4 m</td><td>5 200 - 7 800 €</td></tr>
+          <tr><td>Haut de gamme chêne</td><td>4×5 m</td><td>9 500 - 15 000 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs. Devis personnalisé sur visite gratuite.</em></p>
+
+      <h2>Pourquoi nous choisir à Mérignac ?</h2>
+      <ul>
+        <li><strong>Maîtrise du PLU mérignacais</strong> et déclarations préalables</li>
+        <li><strong>Solutions intimité</strong> pour les parcelles rapprochées (claustra latéral + pergola)</li>
+        <li><strong>Pose adaptée au sol argileux</strong>, plots dimensionnés pour stabilité long terme</li>
+        <li><strong>Proximité Saint-Jean d'Illac</strong> : intervention rapide, SAV réactif</li>
+        <li><strong>Garantie décennale</strong>, note clients 5/5, références sur Arlac, Le Burck, Pichey</li>
+      </ul>
+
+      <h2>Autres services à Mérignac et communes voisines</h2>
+      <div class="local-links">
+        <a href="cloture-bois-merignac.html">Clôture bois Mérignac</a>
+        <a href="terrasse-bois-merignac.html">Terrasse bois Mérignac</a>
+        <a href="pergola-bois-pessac.html">Pergola Pessac</a>
+        <a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — pergola bois à Mérignac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Déclaration préalable pour une pergola à Mérignac ?</summary>
+        <div class="faq-answer"><p>Obligatoire dès que la pergola dépasse 5 m² et reste inférieure à 20 m². Au-delà : permis de construire. Le PLU mérignacais peut imposer des prescriptions selon le secteur (zone UA dense, UC résidentiel). Nous préparons et déposons le Cerfa pour vous.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Comment préserver son intimité avec une pergola à Mérignac ?</summary>
+        <div class="faq-answer"><p>Trois leviers cumulables : 1) hauteur de pergola modulée selon vue des voisins ; 2) claustra bois latéral sur un ou deux côtés ; 3) plantes grimpantes (glycine, jasmin) sur la structure. Combinés, ils créent un cocon visuel total sans rendre la pergola oppressante.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Pergola autoportée sur terrasse béton existante ?</summary>
+        <div class="faq-answer"><p>Possible, deux options : 1) ancrage chimique sur la dalle (si épaisseur suffisante et armée) ; 2) plots indépendants traversant la dalle (carottage). Étude au cas par cas selon nature et état de la dalle.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Durée de vie d'une pergola bois à Mérignac ?</summary>
+        <div class="faq-answer"><p>Pin lamellé-collé classe 4 : 20-25 ans avec entretien régulier (saturateur tous les 3 ans). Douglas : 25-30 ans. Chêne : 40-50 ans. Les vents et la pluviométrie locale n'altèrent pas significativement la longévité avec un bon entretien.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre pergola bois à Mérignac — devis gratuit</h2>
+        <p>Étude technique offerte, intervention rapide depuis Saint-Jean d'Illac.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan pergola, clôture et terrasse bois à Mérignac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="pergola-bois-merignac.html">Pergola Mérignac</a></li>
+            <li><a href="cloture-bois-merignac.html">Clôture Mérignac</a></li>
+            <li><a href="terrasse-bois-merignac.html">Terrasse Mérignac</a></li>
+            <li><a href="pergola-bois-pessac.html">Pergola Pessac</a></li>
+            <li><a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Conception et pose de pergola bois sur mesure",
+    "name": "Pergola bois Mérignac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Mérignac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Bordeaux Métropole"}},
+    "description": "Pergolas bois sur mesure à Mérignac : adossée, autoportée, persiennes orientables, claustra intimité, toile rétractable.",
+    "offers": {"@type": "Offer", "priceRange": "3000-15000 EUR", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Pergola bois Mérignac", "item": "https://elegance-bois.fr/pergola-bois-merignac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/pergola-bois-pessac.html
+++ b/pergola-bois-pessac.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Pergola Bois Pessac (33600) | Sur Mesure Artisan - Élégance Bois</title>
+  <meta name="description" content="Pergola bois sur mesure à Pessac (33600) : adossée, autoportée, persiennes orientables. Pin lamellé-collé, douglas, chêne. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="pergola bois Pessac, pergola bois 33600, pergola adossée Pessac, pergola persiennes Pessac, pergola sur mesure Pessac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Pessac, Gironde">
+  <meta name="geo.position" content="44.8067;-0.6311">
+  <meta name="ICBM" content="44.8067, -0.6311">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Pergola Bois Pessac (33600) | Élégance Bois">
+  <meta property="og:description" content="Pergola bois sur mesure à Pessac. Adossée, autoportée, persiennes orientables. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/pergola-bois-pessac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/pergola-persienne.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/pergola-bois-pessac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/pergola-persienne.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/pergola-persienne.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Pergola bois</a></li>
+        <li aria-current="page">Pessac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Pergola Bois Sur Mesure à Pessac</h1>
+        <p class="hero-tagline">Étendez votre intérieur jusque dans le jardin</p>
+        <p>Pergolas bois adossées, autoportées, à persiennes orientables pour les jardins pessacais (33600).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>À Pessac, la pergola devient une véritable <strong>pièce de vie extérieure</strong>. Les jardins généreux de Saige, Magonty ou Cap-de-Bos s'y prêtent particulièrement : pergola adossée au-dessus d'une terrasse pour prolonger le salon, structure autoportée au fond du jardin pour créer un coin repas indépendant, persiennes orientables pour moduler l'ombre selon l'heure de la journée.</p>
+        <p>Le climat océanique pessacais — étés chauds, hivers doux mais pluvieux — appelle une structure capable de gérer des conditions variables. Nos pergolas en <strong>pin lamellé-collé classe 4 ou douglas</strong> sont calculées pour les vents locaux (jusqu'à 110-130 km/h) et la charge neige réglementaire de la zone.</p>
+        <p>Notre proximité depuis Saint-Jean d'Illac nous permet d'intervenir rapidement sur tous les quartiers pessacais, du Bourg patrimonial aux résidences contemporaines de Magonty.</p>
+      </div>
+
+      <h2>Types de pergolas à Pessac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Pergola adossée à la maison</h3>
+          <p>Prolongement de la pièce à vivre vers le jardin. La plus naturelle, la plus demandée pour les pavillons pessacais.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola autoportée</h3>
+          <p>Idéale pour les grands jardins de Saige, Magonty, Cap-de-Bos. Crée un point d'ancrage extérieur indépendant.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Persiennes orientables motorisées</h3>
+          <p>Lames pivotantes commandées par télécommande ou capteur soleil. Confort moderne pour villas contemporaines.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Toile rétractable</h3>
+          <p>Solution flexible : ombre à la demande, ciel ouvert quand vous voulez. Manuelle ou motorisée.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola tour de piscine</h3>
+          <p>Combinée à votre terrasse piscine pour créer un coin lecture ombragé. Bois traité résistant chlore.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola bioclimatique sur cadre bois</h3>
+          <p>Mariage du bois structurel et lames aluminium orientables. Élégance bois + performance technique.</p>
+        </div>
+      </div>
+
+      <h2>Essences bois recommandées à Pessac</h2>
+      <ul>
+        <li><strong>Pin lamellé-collé classe 4</strong> : structure stable sur grandes portées, traitement profond.</li>
+        <li><strong>Douglas</strong> : sans traitement chimique, durabilité naturelle, tons chauds.</li>
+        <li><strong>Mélèze</strong> : peu de mouvement, idéal sur structures fines et lignes épurées.</li>
+        <li><strong>Chêne</strong> : pour pergolas patrimoniales en cohérence avec échoppes ou villas anciennes.</li>
+        <li><strong>Ipé / Cumaru</strong> : pour les couvertures ou lames apparentes à très longue durée de vie.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Pessac</strong>Mesures, exposition, intégration architecturale (échoppe ? villa moderne ? pavillon ?).</li>
+        <li><strong>Plan personnalisé</strong>Implantation, type de couverture, choix essence, dimensionnement vents/neige.</li>
+        <li><strong>Déclaration préalable mairie</strong>Obligatoire pour pergola adossée > 5 m². Nous préparons le dossier complet.</li>
+        <li><strong>Fabrication et pose</strong>2 à 5 jours selon dimensions. Ancrages adaptés au sol argileux de la métropole.</li>
+        <li><strong>Finitions et garantie</strong>Lasure ou saturateur, électrification (LED, store motorisé) en option. Garantie décennale.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une pergola bois à Pessac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type de pergola</th><th>Surface</th><th>Tarif (pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Adossée pin lamellé</td><td>3×4 m</td><td>3 000 - 4 500 €</td></tr>
+          <tr><td>Adossée douglas</td><td>3×4 m</td><td>4 000 - 5 800 €</td></tr>
+          <tr><td>Autoportée pin lamellé</td><td>4×4 m</td><td>4 500 - 6 500 €</td></tr>
+          <tr><td>Avec persiennes orientables</td><td>3×4 m</td><td>5 800 - 9 000 €</td></tr>
+          <tr><td>Avec toile rétractable motorisée</td><td>3×4 m</td><td>5 500 - 8 500 €</td></tr>
+          <tr><td>Haut de gamme chêne</td><td>4×5 m</td><td>9 500 - 15 000 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs hors options. Devis personnalisé sur visite gratuite.</em></p>
+
+      <h2>Pourquoi nous choisir pour votre pergola à Pessac ?</h2>
+      <ul>
+        <li><strong>Maîtrise du PLU pessacais</strong> et des règles d'urbanisme par secteur (patrimonial, pavillonnaire, contemporain)</li>
+        <li><strong>Ancrages adaptés au sol argileux</strong> de la métropole bordelaise</li>
+        <li><strong>Intervention rapide</strong> depuis Saint-Jean d'Illac (~20 min vers Pessac)</li>
+        <li><strong>Cohérence stylistique</strong> avec votre clôture / terrasse bois si réalisées ensemble</li>
+        <li><strong>Garantie décennale</strong>, assurance professionnelle, références locales</li>
+      </ul>
+
+      <h2>Autres services à Pessac et communes voisines</h2>
+      <div class="local-links">
+        <a href="cloture-bois-pessac.html">Clôture bois Pessac</a>
+        <a href="terrasse-bois-pessac.html">Terrasse bois Pessac</a>
+        <a href="pergola-bois-merignac.html">Pergola Mérignac</a>
+        <a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — pergola bois à Pessac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Faut-il un permis pour une pergola à Pessac ?</summary>
+        <div class="faq-answer"><p>Pergola entre 5 et 20 m² : déclaration préalable à la mairie de Pessac. Plus de 20 m² : permis de construire. Dans les secteurs patrimoniaux (centre-bourg, abords églises classées), l'avis de l'ABF peut être requis. Nous gérons l'ensemble du dossier.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Pergola adossée à une échoppe pessacaise : possible ?</summary>
+        <div class="faq-answer"><p>Oui, fréquemment réalisé. La structure s'ancre à la façade ou à un sommier indépendant si la façade ne permet pas la charge. Nous étudions la maçonnerie existante (pierre, parpaing, ossature) avant de proposer le mode de fixation adapté.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Combien de temps dure une pergola bois à Pessac ?</summary>
+        <div class="faq-answer"><p>Pin lamellé-collé classe 4 : 20-25 ans avec entretien (saturateur tous les 3 ans). Douglas : 25-30 ans. Chêne : 40+ ans. Les lames de couverture ipé : 50+ ans.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Délais pour une pergola à Pessac ?</summary>
+        <div class="faq-answer"><p>Visite 48h, étude 1 semaine, instruction DP en mairie 4-6 semaines, fabrication en parallèle 2-3 semaines, pose 2-5 jours. Délai global 6 à 12 semaines selon complexité.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre pergola bois à Pessac — devis gratuit</h2>
+        <p>Étude technique offerte, intervention sous 6 à 12 semaines.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan pergola, clôture et terrasse bois à Pessac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="pergola-bois-pessac.html">Pergola Pessac</a></li>
+            <li><a href="cloture-bois-pessac.html">Clôture Pessac</a></li>
+            <li><a href="terrasse-bois-pessac.html">Terrasse Pessac</a></li>
+            <li><a href="pergola-bois-merignac.html">Pergola Mérignac</a></li>
+            <li><a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Conception et pose de pergola bois sur mesure",
+    "name": "Pergola bois Pessac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Pessac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Bordeaux Métropole"}},
+    "description": "Pergolas bois sur mesure à Pessac : adossée, autoportée, persiennes orientables, toile rétractable. Pin lamellé, douglas, chêne.",
+    "offers": {"@type": "Offer", "priceRange": "3000-15000 EUR", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Pergola bois Pessac", "item": "https://elegance-bois.fr/pergola-bois-pessac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/pergola-bois-saint-jean-d-illac.html
+++ b/pergola-bois-saint-jean-d-illac.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Pergola Bois Saint-Jean d'Illac (33127) | Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Pergola bois sur mesure à Saint-Jean d'Illac : adossée, autoportée, persiennes orientables. Pin lamellé-collé, douglas. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="pergola bois Saint-Jean d'Illac, pergola bois 33127, pergola adossée Saint-Jean d'Illac, pergola persiennes orientables Saint-Jean d'Illac, abri terrasse bois Illac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Saint-Jean d'Illac, Gironde">
+  <meta name="geo.position" content="44.8167;-0.7833">
+  <meta name="ICBM" content="44.8167, -0.7833">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Pergola Bois Saint-Jean d'Illac (33127) | Élégance Bois">
+  <meta property="og:description" content="Pergola bois sur mesure à Saint-Jean d'Illac. Adossée, autoportée, persiennes. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/pergola-bois-saint-jean-d-illac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/pergola.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/pergola-bois-saint-jean-d-illac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/pergola.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/pergola.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Pergola bois</a></li>
+        <li aria-current="page">Saint-Jean d'Illac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Pergola Bois Sur Mesure à Saint-Jean d'Illac</h1>
+        <p class="hero-tagline">Votre artisan local pour un extérieur ombragé toute saison</p>
+        <p>Adossée, autoportée, persiennes orientables — pergolas bois sur mesure conçues à Saint-Jean d'Illac (33127).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Saint-Jean d'Illac bénéficie d'une exposition généreuse au soleil estival, avec des après-midis chaudes de juin à septembre. La pergola bois y trouve son usage idéal : <strong>créer une zone d'ombre fraîche</strong> sur la terrasse, prolonger le repas dans le jardin, abriter un coin lecture. Implantés sur la commune, nous concevons et posons votre pergola en moins de 4 semaines.</p>
+        <p>Sur le sol sableux illacais, l'ancrage de la pergola — qu'elle soit adossée à la façade ou autoportée — exige des plots béton armé descendus à 60-80 cm. La structure bois doit aussi résister aux <strong>vents soutenus venant du Bassin d'Arcachon</strong> en automne. Nous dimensionnons les poteaux et fermes en conséquence.</p>
+      </div>
+
+      <h2>Types de pergolas que nous concevons à Saint-Jean d'Illac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Pergola adossée</h3>
+          <p>Fixée à la façade de votre maison, prolonge naturellement la pièce de vie vers le jardin. La plus demandée.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola autoportée</h3>
+          <p>Indépendante, installée au milieu du jardin ou au-dessus d'une terrasse éloignée. Liberté d'implantation totale.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Persiennes orientables</h3>
+          <p>Lames pivotantes pour moduler l'ombre selon l'heure. Idéal sur les terrasses exposées plein sud, fréquentes à Illac.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Toile rétractable</h3>
+          <p>Toile coulissante manuelle ou motorisée : ombre à la demande, ciel ouvert quand vous voulez.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola toit végétal</h3>
+          <p>Structure conçue pour accueillir glycine, vigne, kiwi. Ombre vivante et évolutive avec les saisons.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Pergola sur terrasse existante</h3>
+          <p>Ancrage léger sur dalle béton ou plots dédiés, sans abîmer votre terrasse actuelle.</p>
+        </div>
+      </div>
+
+      <h2>Essences bois recommandées à Saint-Jean d'Illac</h2>
+      <p>Une pergola subit pluie, soleil et vent en continu. L'essence doit être à la hauteur :</p>
+      <ul>
+        <li><strong>Pin lamellé-collé classe 4</strong> : excellent rapport prix/performance, structure stable, sections importantes possibles.</li>
+        <li><strong>Douglas</strong> : durable naturellement, tons chaleureux, esthétique soignée.</li>
+        <li><strong>Mélèze</strong> : très stable, peu de fente même sur grandes portées.</li>
+        <li><strong>Chêne</strong> : pour pergolas d'exception, longévité 40+ ans, esthétique noble.</li>
+        <li><strong>Ipé</strong> : pour les lames de couverture, durée 50+ ans.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Saint-Jean d'Illac</strong>Sous 48h. Mesures, orientation solaire, intégration architecturale, usage prévu.</li>
+        <li><strong>Étude et plan personnalisé</strong>Dimensions, type de couverture, choix essence, calcul des sections selon vents et neige.</li>
+        <li><strong>Démarches administratives</strong>Pergola adossée > 5 m² ou autoportée > 5 m² : déclaration préalable obligatoire. Nous gérons le dossier.</li>
+        <li><strong>Fabrication et pose</strong>Atelier local. Pose en 2 à 5 jours selon dimensions et options. Ancrages adaptés au sol sableux.</li>
+        <li><strong>Finitions et garantie</strong>Lasure ou saturateur, électrification si options (éclairage LED, store motorisé). Garantie décennale.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une pergola bois à Saint-Jean d'Illac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type de pergola</th><th>Surface</th><th>Tarif (pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Adossée pin lamellé</td><td>3×4 m (12 m²)</td><td>2 800 - 4 200 €</td></tr>
+          <tr><td>Adossée douglas</td><td>3×4 m (12 m²)</td><td>3 800 - 5 500 €</td></tr>
+          <tr><td>Autoportée pin lamellé</td><td>4×4 m (16 m²)</td><td>4 200 - 6 000 €</td></tr>
+          <tr><td>Avec persiennes orientables</td><td>3×4 m</td><td>5 500 - 8 500 €</td></tr>
+          <tr><td>Avec toile rétractable</td><td>3×4 m</td><td>5 000 - 7 500 €</td></tr>
+          <tr><td>Haut de gamme chêne</td><td>4×5 m</td><td>9 000 - 14 000 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs, options éclairage / store / motorisation en supplément. Devis gratuit.</em></p>
+
+      <h2>Pourquoi un artisan local pour votre pergola à Saint-Jean d'Illac ?</h2>
+      <ul>
+        <li><strong>Implantation dans la commune</strong> : maintenance future facilitée, réajustements ou ajouts simples</li>
+        <li><strong>Dimensionnement adapté</strong> aux vents girondins et au sol sableux</li>
+        <li><strong>Connaissance du PLU illacais</strong> et procédures déclaratives</li>
+        <li><strong>Cohérence stylistique</strong> possible avec votre clôture / terrasse bois si réalisées par nos soins</li>
+        <li><strong>Garantie décennale</strong>, références locales visibles</li>
+      </ul>
+
+      <h2>Autres services à Saint-Jean d'Illac</h2>
+      <div class="local-links">
+        <a href="cloture-bois-saint-jean-d-illac.html">Clôture bois Saint-Jean d'Illac</a>
+        <a href="terrasse-bois-saint-jean-d-illac.html">Terrasse bois Saint-Jean d'Illac</a>
+        <a href="pergola-bois-pessac.html">Pergola bois Pessac</a>
+        <a href="pergola-bois-merignac.html">Pergola bois Mérignac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — pergola bois à Saint-Jean d'Illac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Faut-il une déclaration pour une pergola à Saint-Jean d'Illac ?</summary>
+        <div class="faq-answer"><p>Pergola adossée ou autoportée de plus de 5 m² et moins de 20 m² : déclaration préalable obligatoire. Au-delà de 20 m² : permis de construire. Nous préparons les Cerfa et déposons à la mairie d'Illac.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quelle pergola résiste au vent du Bassin d'Arcachon ?</summary>
+        <div class="faq-answer"><p>Toutes nos pergolas sont calculées pour vents 110-130 km/h. Le pin lamellé-collé en sections 14×14 ou 16×16 cm, ancré sur plots béton 60 cm, supporte parfaitement les coups de vent automnaux courants à Illac. La toile rétractable doit être repliée en cas de tempête annoncée.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Pergola persiennes orientables ou toile rétractable, quoi choisir ?</summary>
+        <div class="faq-answer"><p>Persiennes orientables : modulation fine de l'ombre selon l'heure, étanchéité possible (lames jointives), motorisation simple, durabilité 20+ ans. Toile rétractable : ciel ouvert quand replié, moins cher à l'achat, durée vie toile 8-12 ans. Persiennes = investissement durable ; toile = flexibilité immédiate.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Délai pour installer une pergola à Saint-Jean d'Illac ?</summary>
+        <div class="faq-answer"><p>Visite 48h, étude 1 semaine, démarches mairie 4-6 semaines (instruction DP), fabrication 2-3 semaines en parallèle, pose 2-5 jours. Délai global : 6 à 10 semaines pour les modèles simples, 10 à 14 semaines pour les options avancées (persiennes motorisées).</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre pergola bois à Saint-Jean d'Illac — devis gratuit</h2>
+        <p>Étude technique offerte, déplacement immédiat sur la commune.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan pergola, clôture et terrasse bois à Saint-Jean d'Illac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a></li>
+            <li><a href="pergola-bois-pessac.html">Pergola Pessac</a></li>
+            <li><a href="pergola-bois-merignac.html">Pergola Mérignac</a></li>
+            <li><a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a></li>
+            <li><a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Conception et pose de pergola bois sur mesure",
+    "name": "Pergola bois Saint-Jean d'Illac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Saint-Jean d'Illac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Gironde"}},
+    "description": "Pergolas bois sur mesure à Saint-Jean d'Illac : adossée, autoportée, persiennes orientables, toile rétractable. Pin lamellé, douglas, chêne.",
+    "offers": {"@type": "Offer", "priceRange": "2800-14000 EUR", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Pergola bois Saint-Jean d'Illac", "item": "https://elegance-bois.fr/pergola-bois-saint-jean-d-illac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,9 +4,69 @@
     <!-- Page d'accueil -->
     <url>
         <loc>https://elegance-bois.fr/</loc>
-        <lastmod>2026-04-25</lastmod>
+        <lastmod>2026-06-11</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
+    </url>
+
+    <!-- Pages locales Clôture -->
+    <url>
+        <loc>https://elegance-bois.fr/cloture-bois-saint-jean-d-illac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://elegance-bois.fr/cloture-bois-pessac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://elegance-bois.fr/cloture-bois-merignac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+
+    <!-- Pages locales Terrasse -->
+    <url>
+        <loc>https://elegance-bois.fr/terrasse-bois-saint-jean-d-illac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://elegance-bois.fr/terrasse-bois-pessac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://elegance-bois.fr/terrasse-bois-merignac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+
+    <!-- Pages locales Pergola -->
+    <url>
+        <loc>https://elegance-bois.fr/pergola-bois-saint-jean-d-illac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://elegance-bois.fr/pergola-bois-pessac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://elegance-bois.fr/pergola-bois-merignac.html</loc>
+        <lastmod>2026-06-11</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
     </url>
 
     <!-- Mentions légales -->

--- a/styles.css
+++ b/styles.css
@@ -2485,3 +2485,502 @@ nav a:focus-visible {
     padding: 0.5rem;
   }
 }
+
+/* ===== Local Landing Pages ===== */
+.landing-hero {
+  position: relative;
+  min-height: 56vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--color-white);
+  padding: var(--space-2xl) 5% var(--space-xl);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.landing-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--landing-hero-img, url('img/header.webp')) center/cover no-repeat;
+  z-index: -2;
+}
+
+.landing-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120% 80% at 50% 40%, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.55) 70%),
+    linear-gradient(135deg, rgba(74, 37, 8, 0.35), rgba(26, 26, 26, 0.45));
+  z-index: -1;
+}
+
+.landing-hero-content {
+  max-width: 760px;
+  padding: var(--space-xl) var(--space-xl) var(--space-lg);
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.42) 0%, rgba(0, 0, 0, 0.3) 100%);
+  border: 1px solid rgba(201, 169, 110, 0.18);
+  border-radius: var(--radius-sm);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  position: relative;
+}
+
+@supports (backdrop-filter: blur(16px)) {
+  .landing-hero-content {
+    backdrop-filter: blur(16px) saturate(1.3);
+    -webkit-backdrop-filter: blur(16px) saturate(1.3);
+  }
+}
+
+.landing-hero-content::before,
+.landing-hero-content::after {
+  content: '';
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--color-gold);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.landing-hero-content::before {
+  top: -1px;
+  left: -1px;
+  border-right: none;
+  border-bottom: none;
+}
+
+.landing-hero-content::after {
+  bottom: -1px;
+  right: -1px;
+  border-left: none;
+  border-top: none;
+}
+
+.landing-hero h1 {
+  font-family: var(--font-main);
+  font-size: clamp(1.85rem, 4.5vw + 0.3rem, 3rem);
+  font-weight: 600;
+  letter-spacing: var(--track-tight);
+  line-height: 1.12;
+  margin-bottom: var(--space-sm);
+  color: var(--color-white);
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+}
+
+.landing-hero h1::after {
+  content: '';
+  display: block;
+  width: 48px;
+  height: 1px;
+  background: var(--color-gold);
+  opacity: 0.75;
+  margin: var(--space-sm) auto 0;
+}
+
+.landing-hero .hero-tagline {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: clamp(1.05rem, 2vw + 0.2rem, 1.35rem);
+  letter-spacing: 0.02em;
+  margin: var(--space-sm) 0 var(--space-md);
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+.landing-hero p {
+  font-size: var(--text-base);
+  line-height: 1.7;
+  margin-bottom: var(--space-lg);
+  color: rgba(255, 255, 255, 0.88);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.breadcrumb {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: calc(65px + var(--space-md)) 5% var(--space-md);
+  font-size: var(--text-xs);
+  letter-spacing: var(--track-wide);
+  text-transform: uppercase;
+  color: var(--color-gray);
+}
+
+.breadcrumb ol {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 0;
+  margin: 0;
+}
+
+.breadcrumb li:not(:last-child)::after {
+  content: '›';
+  margin-left: var(--space-xs);
+  color: var(--color-gold);
+  opacity: 0.7;
+}
+
+.breadcrumb a {
+  color: var(--color-wood-dark);
+  text-decoration: none;
+  transition: color var(--transition-default);
+}
+
+.breadcrumb a:hover {
+  color: var(--color-gold-soft);
+}
+
+.breadcrumb [aria-current='page'] {
+  color: var(--color-wood);
+  font-weight: 500;
+}
+
+.landing-page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: var(--space-2xl) 5% var(--space-2xl);
+  font-family: var(--font-main);
+  line-height: 1.75;
+  color: var(--color-text);
+}
+
+.landing-page h2 {
+  font-family: var(--font-main);
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  color: var(--color-wood-dark);
+  letter-spacing: var(--track-tight);
+  line-height: 1.2;
+  margin: var(--space-xl) 0 var(--space-md);
+  position: relative;
+  padding-bottom: var(--space-sm);
+}
+
+.landing-page h2::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 44px;
+  height: 1px;
+  background: var(--color-gold);
+  opacity: 0.65;
+}
+
+.landing-page h3 {
+  font-family: var(--font-serif);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-wood-dark);
+  letter-spacing: var(--track-tight);
+  margin: var(--space-md) 0 var(--space-xs);
+}
+
+.landing-page p {
+  font-size: var(--text-base);
+  margin-bottom: var(--space-md);
+}
+
+.landing-page ul,
+.landing-page ol {
+  padding-left: 1.5rem;
+  margin-bottom: var(--space-md);
+}
+
+.landing-page ul li,
+.landing-page ol li {
+  margin-bottom: var(--space-xs);
+}
+
+.landing-intro {
+  font-size: var(--text-lg);
+  color: var(--color-text);
+  background: var(--color-surface-warm);
+  border: 1px solid var(--color-hairline);
+  border-left: 2px solid var(--color-gold);
+  padding: var(--space-lg) var(--space-xl);
+  border-radius: var(--radius-sm);
+  margin: var(--space-md) 0 var(--space-xl);
+  box-shadow: var(--shadow-small);
+}
+
+.landing-intro p:last-child {
+  margin-bottom: 0;
+}
+
+.landing-features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-md);
+  margin: var(--space-md) 0 var(--space-xl);
+}
+
+.feature-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-hairline);
+  border-left: 2px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-small);
+  transition:
+    transform 0.4s var(--ease-out-expo),
+    box-shadow 0.4s var(--ease-out-expo),
+    border-color 0.4s var(--ease-out-expo);
+}
+
+.feature-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-medium);
+  border-left-color: var(--color-gold);
+}
+
+.feature-card h3 {
+  margin: 0 0 var(--space-xs);
+  font-size: var(--text-lg);
+  color: var(--color-wood-dark);
+}
+
+.feature-card p {
+  font-size: var(--text-sm);
+  line-height: 1.7;
+  margin-bottom: 0;
+  color: var(--color-text);
+}
+
+.landing-process {
+  counter-reset: step;
+  list-style: none;
+  padding: 0;
+  margin: var(--space-md) 0 var(--space-xl);
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.landing-process li {
+  counter-increment: step;
+  position: relative;
+  padding: var(--space-md) var(--space-md) var(--space-md) calc(var(--space-2xl) + 1rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-small);
+  font-size: var(--text-base);
+  transition:
+    transform 0.4s var(--ease-out-expo),
+    box-shadow 0.4s var(--ease-out-expo);
+}
+
+.landing-process li:hover {
+  transform: translateX(2px);
+  box-shadow: var(--shadow-medium);
+}
+
+.landing-process li::before {
+  content: counter(step, decimal-leading-zero);
+  position: absolute;
+  left: var(--space-md);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.4rem;
+  height: 2.4rem;
+  background: linear-gradient(135deg, var(--color-olive), var(--color-olive-dark));
+  color: var(--color-white);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: var(--track-tight);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.landing-process strong {
+  display: block;
+  color: var(--color-wood-dark);
+  font-family: var(--font-serif);
+  font-weight: 600;
+  margin-bottom: var(--space-2xs);
+  letter-spacing: var(--track-tight);
+}
+
+.landing-cta {
+  position: relative;
+  background:
+    linear-gradient(135deg, var(--color-wood) 0%, var(--color-wood-darker) 100%);
+  color: var(--color-white);
+  text-align: center;
+  padding: var(--space-2xl) var(--space-xl);
+  border-radius: var(--radius-sm);
+  margin: var(--space-2xl) 0 var(--space-md);
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: var(--shadow-medium);
+}
+
+.landing-cta::before,
+.landing-cta::after {
+  content: '';
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--color-gold);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.landing-cta::before {
+  top: 1rem;
+  left: 1rem;
+  border-right: none;
+  border-bottom: none;
+}
+
+.landing-cta::after {
+  bottom: 1rem;
+  right: 1rem;
+  border-left: none;
+  border-top: none;
+}
+
+.landing-cta h2 {
+  color: var(--color-white);
+  margin: 0 0 var(--space-md);
+  padding-bottom: var(--space-sm);
+  font-family: var(--font-main);
+  letter-spacing: var(--track-tight);
+}
+
+.landing-cta h2::after {
+  background: var(--color-gold);
+  opacity: 0.75;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 44px;
+}
+
+.landing-cta p {
+  margin-bottom: var(--space-lg);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: var(--text-base);
+}
+
+.local-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin: var(--space-md) 0 var(--space-xl);
+}
+
+.local-links a {
+  background: var(--color-surface-warm);
+  border: 1px solid var(--color-hairline);
+  color: var(--color-wood-dark);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: 999px;
+  text-decoration: none;
+  font-size: var(--text-sm);
+  letter-spacing: var(--track-normal);
+  transition:
+    background var(--transition-default),
+    color var(--transition-default),
+    border-color var(--transition-default),
+    transform var(--transition-default);
+}
+
+.local-links a:hover {
+  background: var(--color-wood-dark);
+  color: var(--color-white);
+  border-color: var(--color-wood-dark);
+  transform: translateY(-1px);
+}
+
+/* Landing page tweaks for shared modules */
+.landing-page .data-table {
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  box-shadow: var(--shadow-small);
+  border: 1px solid var(--color-hairline);
+}
+
+.landing-page .data-table th {
+  background: var(--color-wood-dark);
+  font-family: var(--font-serif);
+  letter-spacing: var(--track-tight);
+}
+
+.landing-page .data-table td,
+.landing-page .data-table th {
+  border-color: var(--color-hairline);
+}
+
+.landing-page .faq-item {
+  margin-bottom: var(--space-sm);
+}
+
+.zones-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-sm) var(--space-md);
+  margin: var(--space-sm) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.zones-grid li {
+  font-size: var(--text-sm);
+}
+
+.zones-grid a {
+  color: rgba(255, 255, 255, 0.78);
+  text-decoration: none;
+  transition: color var(--transition-default);
+}
+
+.zones-grid a:hover {
+  color: var(--color-gold);
+}
+
+@media (max-width: 768px) {
+  .landing-hero {
+    min-height: 48vh;
+    padding: var(--space-xl) 5% var(--space-lg);
+  }
+
+  .landing-hero-content {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .landing-page {
+    padding: var(--space-xl) 5%;
+  }
+
+  .landing-intro {
+    padding: var(--space-md) var(--space-lg);
+  }
+
+  .landing-process li {
+    padding-left: calc(var(--space-2xl) + 0.5rem);
+  }
+
+  .landing-cta {
+    padding: var(--space-xl) var(--space-md);
+  }
+
+  .zones-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/terrasse-bois-merignac.html
+++ b/terrasse-bois-merignac.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Terrasse Bois Mérignac (33700) | Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Terrasse bois sur mesure à Mérignac (33700) : tour de piscine, plain-pied, pilotis. Pin, douglas, ipé. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="terrasse bois Mérignac, terrasse piscine Mérignac, terrasse bois 33700, terrasse ipé Mérignac, terrasse Arlac, terrasse Capeyron">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Mérignac, Gironde">
+  <meta name="geo.position" content="44.8417;-0.6533">
+  <meta name="ICBM" content="44.8417, -0.6533">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Terrasse Bois Mérignac (33700) | Élégance Bois">
+  <meta property="og:description" content="Création terrasse bois sur mesure à Mérignac. Piscine, plain-pied, pilotis. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/terrasse-bois-merignac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/terrasse-multi-niveaux.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/terrasse-bois-merignac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/terrasse-multi-niveaux.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/terrasse-multi-niveaux.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Terrasse bois</a></li>
+        <li aria-current="page">Mérignac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Terrasse Bois Sur Mesure à Mérignac</h1>
+        <p class="hero-tagline">Transformez votre jardin mérignacais en pièce à vivre</p>
+        <p>Tour de piscine, plain-pied, pilotis, multi-niveaux — terrasses bois conçues sur mesure à Mérignac (33700).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Mérignac concentre une forte densité de <strong>maisons individuelles avec jardin</strong> dans des quartiers résidentiels recherchés — Arlac, Le Burck, Pichey, Chemin Long. La terrasse bois y devient souvent le centre de gravité de la vie extérieure : repas, détente, espace enfants, transition entre maison et piscine.</p>
+        <p>Sur le plan technique, les sols mérignacais sont essentiellement <strong>argileux à argilo-limoneux</strong>, parfois avec présence de remblais anciens en zones d'urbanisation plus récente. Cela impose une approche rigoureuse : étude préalable, drainage, plots adaptés. Nous le faisons systématiquement.</p>
+        <p>Avantage supplémentaire à Mérignac : une bonne terrasse bois pleine, combinée à un mur végétal ou une pergola, offre un véritable cocon acoustique vis-à-vis du bruit aérien dans les zones proches de l'aéroport.</p>
+      </div>
+
+      <h2>Types de terrasses à Mérignac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Tour de piscine ipé</h3>
+          <p>Notre demande n°1 à Mérignac : habillage d'une piscine maçonnée existante en lames ipé antidérapantes.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse plain-pied</h3>
+          <p>Sur plots réglables ou plots béton selon stabilité du sol. La solution la plus courante pour les pavillons mérignacais.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse sur pilotis</h3>
+          <p>Pour maisons surélevées ou jardins en pente. Structure poteaux bois ou métal, plancher bois.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse multi-niveaux</h3>
+          <p>Paliers reliés par escaliers bois. Idéale pour scinder repas / détente / accès jardin sur grands jardins.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse couverte</h3>
+          <p>Combinée à une pergola adossée — solution complète pour exterior living toute saison.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Reprise terrasse béton</h3>
+          <p>Habillage en lames bois d'une dalle existante. Solution rapide et esthétique sans démolir l'existant.</p>
+        </div>
+      </div>
+
+      <h2>Essences adaptées à Mérignac</h2>
+      <ul>
+        <li><strong>Pin maritime classe 4</strong> : option économique, durée 15-20 ans, idéal pour terrasses cachées au jardin.</li>
+        <li><strong>Douglas</strong> : durable naturellement, sans traitement, vieillit en gris noble.</li>
+        <li><strong>Mélèze</strong> : stable, peu de mouvement dimensionnel, parfait pour terrasses planes critiques.</li>
+        <li><strong>Ipé</strong> : référence absolue tour de piscine, durabilité 50+ ans, antidérapant.</li>
+        <li><strong>Cumaru</strong> : alternative ipé, tons miel, économies réelles sans compromis durabilité.</li>
+        <li><strong>Padouk</strong> : luxe, teinte rouge profonde, pour villas haut de gamme.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite gratuite à Mérignac</strong>Sous 48h. Mesures, sol, exposition, projet d'usage. Tous quartiers : Centre, Capeyron, Arlac, Beutre, Pichey, Beaudésert, Le Burck.</li>
+        <li><strong>Plan et devis détaillés</strong>Implantation, essence, lambourdage, type de fixation (vis apparente ou clip invisible), finitions.</li>
+        <li><strong>Préparation du sol</strong>Décaissement, géotextile, drainage périphérique sur sol argileux, plots béton.</li>
+        <li><strong>Pose</strong>Structure puis lames. Vissage inox A4 ou clips invisibles selon votre choix. Alignement laser.</li>
+        <li><strong>Finitions et garantie</strong>Plinthes, escaliers, saturateur. Garantie décennale, suivi à 1 an.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une terrasse bois à Mérignac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type</th><th>Essence</th><th>Tarif (m², pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Plain-pied standard</td><td>Pin classe 4</td><td>100 - 150 €</td></tr>
+          <tr><td>Plain-pied</td><td>Douglas / Mélèze</td><td>130 - 180 €</td></tr>
+          <tr><td>Tour de piscine</td><td>Pin / Douglas</td><td>140 - 210 €</td></tr>
+          <tr><td>Tour de piscine premium</td><td>Ipé / Cumaru</td><td>210 - 300 €</td></tr>
+          <tr><td>Sur pilotis</td><td>Pin / Douglas</td><td>190 - 280 €</td></tr>
+          <tr><td>Multi-niveaux exotique</td><td>Ipé / Padouk</td><td>240 - 360 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs au m². Devis gratuit avec étude technique sur site.</em></p>
+
+      <h2>Pourquoi nous choisir à Mérignac ?</h2>
+      <ul>
+        <li><strong>Pose adaptée aux sols argileux mérignacais</strong> avec drainage et plots dimensionnés</li>
+        <li><strong>Maîtrise habillage piscine maçonnée</strong> : nombreuses références à Arlac, Le Burck</li>
+        <li><strong>Proximité Saint-Jean d'Illac</strong> : intervention rapide, déplacement offert</li>
+        <li><strong>Bois certifiés FSC</strong> pour les essences exotiques</li>
+        <li><strong>Garantie décennale</strong>, note clients 5/5</li>
+      </ul>
+
+      <h2>Autres services à Mérignac et alentours</h2>
+      <div class="local-links">
+        <a href="cloture-bois-merignac.html">Clôture bois Mérignac</a>
+        <a href="pergola-bois-merignac.html">Pergola bois Mérignac</a>
+        <a href="terrasse-bois-pessac.html">Terrasse Pessac</a>
+        <a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — terrasse bois à Mérignac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Combien coûte une terrasse bois 30 m² à Mérignac ?</summary>
+        <div class="faq-answer"><p>Pour 30 m² plain-pied en pin classe 4 : entre 3 000 et 4 500 € pose comprise. En douglas : 3 900 à 5 400 €. En ipé : 6 300 à 9 000 €. Tarifs indicatifs, dépendent de l'accessibilité du chantier et de la préparation du sol.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Faut-il une autorisation à Mérignac pour une terrasse ?</summary>
+        <div class="faq-answer"><p>Terrasse plain-pied non surélevée : aucune autorisation. Terrasse surélevée de plus de 60 cm ou dépassant 20 m² : déclaration préalable obligatoire à la mairie de Mérignac. Au-delà de 40 m² surélevés : permis de construire. Nous gérons les démarches.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quelle terrasse à proximité de l'aéroport pour limiter le bruit ?</summary>
+        <div class="faq-answer"><p>Le bois ne réduit pas le bruit en lui-même, mais une terrasse couverte (pergola adossée + claustra bois latéral) crée un cocon visuel et acoustique apaisant. Combinée à un mur végétal, elle améliore significativement le confort perçu.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Délais pour une terrasse à Mérignac ?</summary>
+        <div class="faq-answer"><p>Visite et devis sous 48h. Démarrage des travaux 3 à 6 semaines après acceptation (4-6 semaines en haute saison avril-juin). Pose : 2 à 7 jours selon la surface et complexité.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre terrasse bois à Mérignac — devis gratuit</h2>
+        <p>Étude sol + plan + tarif, sous 48h, sans engagement.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan terrasse, clôture et pergola bois à Mérignac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="terrasse-bois-merignac.html">Terrasse Mérignac</a></li>
+            <li><a href="cloture-bois-merignac.html">Clôture Mérignac</a></li>
+            <li><a href="pergola-bois-merignac.html">Pergola Mérignac</a></li>
+            <li><a href="terrasse-bois-pessac.html">Terrasse Pessac</a></li>
+            <li><a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Création de terrasse bois sur mesure",
+    "name": "Terrasse bois Mérignac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Mérignac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Bordeaux Métropole"}},
+    "description": "Création de terrasses bois sur mesure à Mérignac (33700) : plain-pied, piscine, pilotis, multi-niveaux. Pin, douglas, ipé, cumaru.",
+    "offers": {"@type": "Offer", "priceRange": "100-360 EUR/m²", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Terrasse bois Mérignac", "item": "https://elegance-bois.fr/terrasse-bois-merignac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/terrasse-bois-pessac.html
+++ b/terrasse-bois-pessac.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Terrasse Bois Pessac (33600) | Artisan Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Terrasse bois sur mesure à Pessac (33600) : piscine, pilotis, multi-niveaux. Pin classe 4, douglas, ipé, cumaru. Pose adaptée sol argileux. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="terrasse bois Pessac, terrasse piscine Pessac, terrasse bois 33600, terrasse ipé Pessac, terrasse pilotis Pessac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Pessac, Gironde">
+  <meta name="geo.position" content="44.8067;-0.6311">
+  <meta name="ICBM" content="44.8067, -0.6311">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Terrasse Bois Pessac (33600) | Élégance Bois">
+  <meta property="og:description" content="Création terrasse bois sur mesure à Pessac. Piscine, pilotis, multi-niveaux. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/terrasse-bois-pessac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/header.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/terrasse-bois-pessac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/header.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/header.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Terrasse bois</a></li>
+        <li aria-current="page">Pessac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Terrasse Bois Sur Mesure à Pessac</h1>
+        <p class="hero-tagline">Du Bourg à Magonty, créations bois sur mesure</p>
+        <p>Terrasse piscine, pilotis, multi-niveaux : nous créons votre extérieur à Pessac (33600).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Pessac se prête particulièrement bien aux terrasses bois ambitieuses : <strong>jardins généreux dans les quartiers de Saige, Cap-de-Bos et Magonty</strong>, propriétés avec piscine fréquentes, exposition souvent favorable. Notre proximité depuis Saint-Jean d'Illac — moins de 20 minutes — nous permet d'intervenir réactivement sur toute la commune.</p>
+        <p>Le sol pessacais, majoritairement <strong>argilo-limoneux</strong>, exige une attention particulière : risque de retrait-gonflement, drainage à prévoir sous la structure, profondeur des plots adaptée. Une terrasse bien conçue ici tient 25-30 ans sans broncher ; mal posée, elle se déforme dès le 3e été.</p>
+        <p>Nous intervenons régulièrement en habillage de piscine maçonnée, terrasse autour d'échoppe rénovée, ou plateforme bois pour villas contemporaines de Magonty. Chaque projet, son sol, son essence, sa logique structurelle.</p>
+      </div>
+
+      <h2>Types de terrasses bois à Pessac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Terrasse plain-pied</h3>
+          <p>Sur plots réglables PVC ou plots béton selon stabilité requise. Adaptée à la majorité des jardins pessacais.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Habillage tour de piscine</h3>
+          <p>Lames bois exotique antidérapantes autour de votre piscine existante. Confort pieds nus, esthétique chaleureuse.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse sur pilotis</h3>
+          <p>Pour terrains en pente (fréquents à Toctoucau, Romainville) ou maisons en surplomb. Structure poteaux + plancher.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Multi-niveaux design</h3>
+          <p>Plusieurs paliers reliés par escaliers bois. Esprit jardin contemporain pour résidences récentes.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse couverte</h3>
+          <p>Combinée à une pergola adossée pour profiter de l'extérieur toute l'année malgré la pluviométrie pessacaise.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse rénovation</h3>
+          <p>Reprise sur dalle béton existante avec plots ou structure aluminium. Solution rapide, peu invasive.</p>
+        </div>
+      </div>
+
+      <h2>Essences adaptées à Pessac</h2>
+      <p>Climat océanique, étés chauds et secs, hivers doux mais humides : le bois doit gérer ces variations sans broncher.</p>
+      <ul>
+        <li><strong>Pin classe 4 autoclave</strong> : économique, durée 15-20 ans, idéal pour terrasses plain-pied non visibles depuis la rue.</li>
+        <li><strong>Douglas</strong> : naturellement durable sans traitement, tons rouge-orangé, vieillit en gris argenté.</li>
+        <li><strong>Mélèze</strong> : très stable dimensionnellement, parfait quand la planéité est critique (lames jointives).</li>
+        <li><strong>Ipé</strong> : référence absolue pour les tours de piscine, dur, dense, durée 50+ ans, antidérapant.</li>
+        <li><strong>Cumaru</strong> : alternative ipé, tons miel, rapport prestige/prix excellent.</li>
+        <li><strong>Padouk, Massaranduba</strong> : finitions luxe pour villas haut de gamme de Pessac-Léognan.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Rendez-vous gratuit à Pessac</strong>Visite sur site, mesures précises, étude du sol (carotte si nécessaire en zone argileuse).</li>
+        <li><strong>Plan et devis détaillés</strong>Plan d'implantation, choix essence, lambourdage, fixations apparentes ou invisibles, finitions.</li>
+        <li><strong>Préparation du sol</strong>Décaissement, géotextile, drainage si terrain argileux marqué. Plots béton sur sol stabilisé.</li>
+        <li><strong>Pose de la structure et des lames</strong>Lambourdes en pin/aluminium selon projet. Lames vissées inox, espacement réglé pour dilatation.</li>
+        <li><strong>Finitions et livraison</strong>Plinthes, escaliers, profilés. Application saturateur. Garantie décennale.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une terrasse bois à Pessac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type</th><th>Essence</th><th>Tarif (m², pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Plain-pied standard</td><td>Pin classe 4</td><td>100 - 150 €</td></tr>
+          <tr><td>Plain-pied</td><td>Douglas / Mélèze</td><td>130 - 180 €</td></tr>
+          <tr><td>Tour de piscine</td><td>Pin classe 4</td><td>140 - 210 €</td></tr>
+          <tr><td>Tour de piscine premium</td><td>Ipé / Cumaru</td><td>210 - 300 €</td></tr>
+          <tr><td>Sur pilotis</td><td>Pin / Douglas</td><td>190 - 280 €</td></tr>
+          <tr><td>Multi-niveaux exotique</td><td>Ipé / Padouk</td><td>240 - 360 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs au m². Devis personnalisé sur visite gratuite.</em></p>
+
+      <h2>Pourquoi nous choisir à Pessac ?</h2>
+      <ul>
+        <li><strong>Maîtrise du sol argileux pessacais</strong> : drainage, plots adaptés, garantie planéité long terme</li>
+        <li><strong>Intervention rapide</strong> depuis Saint-Jean d'Illac (~15-20 min vers tout Pessac)</li>
+        <li><strong>Références sur la commune</strong> visibles sur demande</li>
+        <li><strong>Bois traçables</strong>, exotiques certifiés FSC</li>
+        <li><strong>Garantie décennale</strong> et SAV réactif</li>
+      </ul>
+
+      <h2>Autres services à Pessac et alentours</h2>
+      <div class="local-links">
+        <a href="cloture-bois-pessac.html">Clôture bois Pessac</a>
+        <a href="pergola-bois-pessac.html">Pergola bois Pessac</a>
+        <a href="terrasse-bois-merignac.html">Terrasse Mérignac</a>
+        <a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — terrasse bois à Pessac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Sol argileux à Pessac : ma terrasse va-t-elle bouger ?</summary>
+        <div class="faq-answer"><p>Pas si la pose est adaptée. Sur sol argileux, nous descendons les plots béton sous la zone de retrait (60-80 cm) et installons un drainage périphérique. Une lambourde aluminium peut être préférée au bois sur certains terrains très instables. Étude au cas par cas pendant la visite.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Faut-il un permis ou déclaration à Pessac pour une terrasse ?</summary>
+        <div class="faq-answer"><p>Terrasse plain-pied non surélevée : aucune formalité. Terrasse de plus de 60 cm de hauteur ou de plus de 20 m² : déclaration préalable obligatoire à la mairie de Pessac. Nous préparons et déposons le dossier.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quelle essence pour une terrasse autour de piscine à Pessac ?</summary>
+        <div class="faq-answer"><p>L'ipé reste la référence pour son antidérapance naturelle, sa densité et sa résistance au chlore. Le cumaru est une excellente alternative, légèrement moins cher. Pour budget contenu, le douglas traité performe correctement. Le pin classe 4 fonctionne mais nécessite plus d'entretien.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Combien dure la pose d'une terrasse à Pessac ?</summary>
+        <div class="faq-answer"><p>30 m² plain-pied : 2-3 jours. 60 m² tour de piscine ipé : 5-6 jours. 80 m² sur pilotis avec garde-corps : 7-10 jours. Délai global devis → pose : 3 à 6 semaines.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre terrasse bois à Pessac — devis gratuit</h2>
+        <p>Étude technique offerte, intervention sous 3 à 6 semaines.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan terrasse, clôture et pergola bois à Pessac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="terrasse-bois-pessac.html">Terrasse Pessac</a></li>
+            <li><a href="cloture-bois-pessac.html">Clôture Pessac</a></li>
+            <li><a href="pergola-bois-pessac.html">Pergola Pessac</a></li>
+            <li><a href="terrasse-bois-merignac.html">Terrasse Mérignac</a></li>
+            <li><a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Création de terrasse bois sur mesure",
+    "name": "Terrasse bois Pessac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Pessac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Bordeaux Métropole"}},
+    "description": "Création de terrasses bois sur mesure à Pessac (33600) : plain-pied, piscine, pilotis, multi-niveaux. Pin, douglas, ipé, cumaru.",
+    "offers": {"@type": "Offer", "priceRange": "100-360 EUR/m²", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Terrasse bois Pessac", "item": "https://elegance-bois.fr/terrasse-bois-pessac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>

--- a/terrasse-bois-saint-jean-d-illac.html
+++ b/terrasse-bois-saint-jean-d-illac.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Terrasse Bois Saint-Jean d'Illac (33127) | Sur Mesure - Élégance Bois</title>
+  <meta name="description" content="Terrasse bois sur mesure à Saint-Jean d'Illac : terrasse piscine, pilotis, multi-niveaux. Pin, ipé, cumaru. Pose adaptée au sol sableux. Devis gratuit ☎ 06 22 73 49 08">
+  <meta name="keywords" content="terrasse bois Saint-Jean d'Illac, terrasse piscine Saint-Jean d'Illac, terrasse bois 33127, terrasse pilotis Saint-Jean d'Illac, lames ipé Saint-Jean d'Illac">
+  <meta name="author" content="Élégance Bois">
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+
+  <meta name="geo.region" content="FR-NAQ">
+  <meta name="geo.placename" content="Saint-Jean d'Illac, Gironde">
+  <meta name="geo.position" content="44.8167;-0.7833">
+  <meta name="ICBM" content="44.8167, -0.7833">
+  <meta name="language" content="French">
+
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Terrasse Bois Saint-Jean d'Illac (33127) | Élégance Bois">
+  <meta property="og:description" content="Création terrasse bois sur mesure à Saint-Jean d'Illac. Piscine, pilotis, multi-niveaux. Devis gratuit.">
+  <meta property="og:url" content="https://elegance-bois.fr/terrasse-bois-saint-jean-d-illac.html">
+  <meta property="og:site_name" content="Élégance Bois">
+  <meta property="og:image" content="https://elegance-bois.fr/img/terrasse-piscine.webp">
+
+  <link rel="canonical" href="https://elegance-bois.fr/terrasse-bois-saint-jean-d-illac.html">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="styles.css" as="style">
+  <link rel="preload" as="image" href="img/terrasse-piscine.webp" fetchpriority="high">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500;600;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"></noscript>
+
+  <link rel="icon" type="image/webp" href="img/logo-elegance-bois.webp">
+  <meta name="theme-color" content="#8B4513">
+  <style>.landing-hero{--landing-hero-img:url('img/terrasse-piscine.webp')}</style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Aller au contenu principal</a>
+
+  <header role="banner">
+    <div class="header-inner">
+      <a href="/" class="logo" aria-label="Élégance Bois - Accueil">
+        <img src="img/logo-elegance-bois.webp" alt="Logo Élégance Bois" width="117" height="61" decoding="async">
+      </a>
+      <button class="menu-toggle" aria-label="Ouvrir le menu" aria-expanded="false" aria-controls="main-nav">
+        <span></span><span></span><span></span>
+      </button>
+      <nav id="main-nav" role="navigation" aria-label="Navigation principale">
+        <ul>
+          <li><a href="/#accueil">Accueil</a></li>
+          <li><a href="/#a-propos">À propos</a></li>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#portfolio">Réalisations</a></li>
+          <li><a href="/#temoignages">Témoignages</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" role="main">
+    <nav class="breadcrumb" aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#services">Terrasse bois</a></li>
+        <li aria-current="page">Saint-Jean d'Illac</li>
+      </ol>
+    </nav>
+
+    <section class="landing-hero">
+      <div class="landing-hero-content">
+        <h1>Terrasse Bois Sur Mesure à Saint-Jean d'Illac</h1>
+        <p class="hero-tagline">L'artisan terrasse implanté dans votre commune</p>
+        <p>Terrasse piscine, sur pilotis, multi-niveaux — créations bois conçues localement à Saint-Jean d'Illac (33127).</p>
+        <a href="/#contact" class="btn-primary">Demander un devis gratuit</a>
+      </div>
+    </section>
+
+    <article class="landing-page">
+      <div class="landing-intro">
+        <p>Notre atelier est implanté <strong>228 rue des Tamaris à Saint-Jean d'Illac</strong>. Cela signifie pour vous : un déplacement immédiat, une connaissance intime du <strong>sol sableux landais</strong> caractéristique de la commune, et la possibilité d'aller voir nos terrasses déjà posées chez vos voisins avant de signer.</p>
+        <p>Le sable d'Illac, drainant et meuble, est un <strong>excellent terrain pour les terrasses sur plots ou lambourdes ventilées</strong> — l'eau ne stagne pas, le bois respire. À l'inverse, il exige des fondations adaptées pour les terrasses sur pilotis : nous descendons des plots béton armé sous la couche superficielle pour garantir la stabilité long terme.</p>
+        <p>Climat océanique tempéré, embruns occasionnels du Bassin d'Arcachon, exposition souvent généreuse : nous conseillons l'essence selon votre projet — pin classe 4 régional pour le rapport qualité-prix, ipé ou cumaru pour la résistance maximale.</p>
+      </div>
+
+      <h2>Types de terrasses que nous réalisons à Saint-Jean d'Illac</h2>
+      <div class="landing-features">
+        <div class="feature-card">
+          <h3>Terrasse de plain-pied</h3>
+          <p>Sur plots réglables ou dalle existante. La plus simple, la plus courante. Adaptée aux jardins illacais plats.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse piscine</h3>
+          <p>Lames antidérapantes, traitement spécifique chlore et UV. Conforme aux contraintes des piscines maçonnées ou coques.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse sur pilotis</h3>
+          <p>Pour terrains en pente douce ou maisons surélevées. Structure poteaux bois ou métal, plancher bois.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse multi-niveaux</h3>
+          <p>Plusieurs paliers reliés par escaliers bois. Idéale pour différencier espaces repas, détente et solarium.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Terrasse avec garde-corps</h3>
+          <p>Pour les terrasses surélevées de plus de 1 m. Garde-corps bois ou inox-bois, conforme normes sécurité.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Habillage tour de piscine</h3>
+          <p>Margelles bois exotique pour habiller une piscine existante. Confort pieds nus, esthétique noble.</p>
+        </div>
+      </div>
+
+      <h2>Essences de bois recommandées à Saint-Jean d'Illac</h2>
+      <p>Notre proximité avec les forêts landaises nous donne accès à des pins de qualité à des conditions optimales. Pour les essences exotiques, nous travaillons avec des fournisseurs certifiés FSC :</p>
+      <ul>
+        <li><strong>Pin maritime classe 4</strong> : essence locale, traitement autoclave, durée 15-20 ans. Le choix raisonné.</li>
+        <li><strong>Douglas</strong> : naturellement durable, sans traitement chimique, tons chauds.</li>
+        <li><strong>Mélèze</strong> : très stable, peu de fente, idéal pour terrasses exposées plein sud.</li>
+        <li><strong>Ipé</strong> : dur, dense, durée 50+ ans, antidérapant naturel — parfait pour tour de piscine.</li>
+        <li><strong>Cumaru</strong> : alternative à l'ipé, légèrement moins cher, performances comparables.</li>
+        <li><strong>Padouk</strong> : pour finitions luxe, teinte rouge profonde.</li>
+      </ul>
+
+      <h2>Notre processus en 5 étapes</h2>
+      <ol class="landing-process">
+        <li><strong>Visite et écoute du projet</strong>Sous 48h à Saint-Jean d'Illac. Mesures, étude du sol, exposition, usage prévu.</li>
+        <li><strong>Plan 2D et devis détaillé</strong>Implantation, niveau, essence, lambourdage, type de fixation, finitions.</li>
+        <li><strong>Préparation du terrain</strong>Décaissement si nécessaire, géotextile anti-herbes, plots réglables ou plots béton sur sable selon projet.</li>
+        <li><strong>Pose des lames</strong>Vissage inox ou fixations invisibles selon votre choix. Sens, espacement, alignement laser.</li>
+        <li><strong>Finitions et livraison</strong>Profilés, plinthes, escaliers, garde-corps. Saturateur en finition. Garantie décennale.</li>
+      </ol>
+
+      <h2>Prix indicatif d'une terrasse bois à Saint-Jean d'Illac</h2>
+      <table class="data-table">
+        <thead><tr><th>Type de terrasse</th><th>Essence</th><th>Tarif (m², pose comprise)</th></tr></thead>
+        <tbody>
+          <tr><td>Plain-pied standard</td><td>Pin classe 4</td><td>90 - 140 €</td></tr>
+          <tr><td>Plain-pied</td><td>Douglas / Mélèze</td><td>120 - 170 €</td></tr>
+          <tr><td>Tour de piscine</td><td>Pin / Douglas</td><td>130 - 200 €</td></tr>
+          <tr><td>Tour de piscine premium</td><td>Ipé / Cumaru</td><td>200 - 290 €</td></tr>
+          <tr><td>Sur pilotis</td><td>Pin classe 4</td><td>180 - 260 €</td></tr>
+          <tr><td>Multi-niveaux exotique</td><td>Ipé / Padouk</td><td>230 - 340 €</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tarifs indicatifs au m², hors options spécifiques. Devis gratuit personnalisé.</em></p>
+
+      <h2>Pourquoi nous choisir pour votre terrasse à Saint-Jean d'Illac ?</h2>
+      <ul>
+        <li><strong>Atelier dans votre commune</strong>, déplacement offert, intervention rapide</li>
+        <li><strong>Maîtrise du sol sableux</strong> spécifique à la commune et à la lisière forestière</li>
+        <li><strong>Références locales visibles</strong> chez vos voisins illacais</li>
+        <li><strong>Bois certifiés</strong>, traçabilité essences exotiques</li>
+        <li><strong>Garantie décennale</strong> + assurance professionnelle complète</li>
+      </ul>
+
+      <h2>Autres services bois à Saint-Jean d'Illac</h2>
+      <div class="local-links">
+        <a href="cloture-bois-saint-jean-d-illac.html">Clôture bois Saint-Jean d'Illac</a>
+        <a href="pergola-bois-saint-jean-d-illac.html">Pergola bois Saint-Jean d'Illac</a>
+        <a href="terrasse-bois-pessac.html">Terrasse bois Pessac</a>
+        <a href="terrasse-bois-merignac.html">Terrasse bois Mérignac</a>
+        <a href="/#services">Tous nos services</a>
+      </div>
+
+      <h2>Questions fréquentes — terrasse bois à Saint-Jean d'Illac</h2>
+      <details class="faq-item">
+        <summary class="faq-question">Une terrasse bois sur sol sableux d'Illac, c'est solide ?</summary>
+        <div class="faq-answer"><p>Oui, à condition d'utiliser des plots réglables drainants ou des plots béton selon le projet. Le sable est en réalité un excellent support : il draine l'eau, n'accumule pas l'humidité sous la terrasse, et limite le risque de pourrissement. Nous adaptons systématiquement la fondation.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Faut-il une déclaration préalable à Saint-Jean d'Illac ?</summary>
+        <div class="faq-answer"><p>Pas de déclaration nécessaire pour une terrasse de plain-pied posée directement sur sol. Pour une terrasse surélevée de plus de 60 cm ou de plus de 20 m², une déclaration préalable est obligatoire. Nous nous chargeons du dossier.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Quel entretien pour une terrasse bois à Illac ?</summary>
+        <div class="faq-answer"><p>Nettoyage karcher basse pression une fois par an, application d'un saturateur tous les 2 à 3 ans pour les essences claires (pin, douglas). Pour l'ipé, simple rinçage suffit — la patine grise est naturelle. Pas de javel jamais : elle attaque le bois.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary class="faq-question">Combien de temps pour poser une terrasse à Saint-Jean d'Illac ?</summary>
+        <div class="faq-answer"><p>30 m² plain-pied : 2-3 jours. 50 m² avec préparation sol : 4-5 jours. Tour de piscine 80 m² ipé : 5-7 jours. Délai global devis → pose : 3 à 6 semaines selon saison.</p></div>
+      </details>
+
+      <div class="landing-cta">
+        <h2>Votre terrasse bois à Saint-Jean d'Illac — devis gratuit</h2>
+        <p>Étude technique offerte, intervention rapide, garantie décennale.</p>
+        <a href="/#contact" class="btn-primary">Demander mon devis</a>
+      </div>
+    </article>
+  </main>
+
+  <footer role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-column">
+          <div class="footer-logo">Élégance Bois</div>
+          <p>Artisan terrasse, clôture et pergola bois à Saint-Jean d'Illac et toute la Gironde.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Pages locales</h4>
+          <ul class="footer-links">
+            <li><a href="terrasse-bois-saint-jean-d-illac.html">Terrasse Saint-Jean d'Illac</a></li>
+            <li><a href="terrasse-bois-pessac.html">Terrasse Pessac</a></li>
+            <li><a href="terrasse-bois-merignac.html">Terrasse Mérignac</a></li>
+            <li><a href="cloture-bois-saint-jean-d-illac.html">Clôture Saint-Jean d'Illac</a></li>
+            <li><a href="pergola-bois-saint-jean-d-illac.html">Pergola Saint-Jean d'Illac</a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Contact</h4>
+          <ul class="footer-links">
+            <li>228 rue des Tamaris, 33127 Saint-Jean d'Illac</li>
+            <li><a href="tel:+33622734908">06 22 73 49 08</a></li>
+            <li><a href="mailto:contact@elegance-bois.fr">contact@elegance-bois.fr</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Élégance Bois | <a href="/mentions-legales.html">Mentions légales</a> | <a href="/politique-confidentialite.html">Confidentialité</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "serviceType": "Création de terrasse bois sur mesure",
+    "name": "Terrasse bois Saint-Jean d'Illac",
+    "provider": {"@type": "HomeAndConstructionBusiness", "name": "Élégance Bois", "telephone": "+33622734908", "url": "https://elegance-bois.fr", "address": {"@type": "PostalAddress", "streetAddress": "228 rue des Tamaris", "addressLocality": "Saint-Jean d'Illac", "postalCode": "33127", "addressCountry": "FR"}},
+    "areaServed": {"@type": "City", "name": "Saint-Jean d'Illac", "containedInPlace": {"@type": "AdministrativeArea", "name": "Gironde"}},
+    "description": "Création de terrasses bois sur mesure à Saint-Jean d'Illac (33127) : plain-pied, piscine, pilotis, multi-niveaux. Pin, douglas, ipé, cumaru.",
+    "offers": {"@type": "Offer", "priceRange": "90-340 EUR/m²", "priceCurrency": "EUR"}
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://elegance-bois.fr/"},
+      {"@type": "ListItem", "position": 2, "name": "Services", "item": "https://elegance-bois.fr/#services"},
+      {"@type": "ListItem", "position": 3, "name": "Terrasse bois Saint-Jean d'Illac", "item": "https://elegance-bois.fr/terrasse-bois-saint-jean-d-illac.html"}
+    ]
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 9 new landing pages: clôture / terrasse / pergola × Saint-Jean d'Illac / Pessac / Mérignac
- Unique content per page (sol local, PLU, climat, quartiers, prix indicatifs, FAQ ville-spécifique) to avoid doorway penalty
- Schema.org Service + BreadcrumbList per page
- Updated sitemap.xml (+9 URLs), index footer (mesh interne), CSS landing module aligned to design tokens
- JS fix: `initHeaderScroll()` extrait pour que `.scrolled` toggle sur pages sans `.hero-bg`

## SEO rationale
Capture long-tail SERP (\"clôture bois Pessac\", \"terrasse piscine Mérignac\", etc.) — accueil seul couvrait SJI + Gironde générique. 9 pages dédiées = profondeur topique + maillage interne.

## Test plan
- [ ] Visite chaque page : header sticky + opaque sur scroll
- [ ] Breadcrumb visible sous header
- [ ] Hero full-bleed avec image bg correcte
- [ ] CTA "Demander devis" → ancre /#contact
- [ ] Liens internes maillage entre pages locales
- [ ] Lighthouse audit (perf/SEO) sur 1-2 pages
- [ ] Validator Schema.org : Service + BreadcrumbList valides
- [ ] Soumettre sitemap dans Search Console après merge